### PR TITLE
Remove extraneous empty lines around diff headers

### DIFF
--- a/src/blockwart/items/files.py
+++ b/src/blockwart/items/files.py
@@ -32,12 +32,11 @@ CONTENT_PROCESSORS = {
 def diff(content_old, content_new, filename):
     output = ""
     for line in unified_diff(
-        content_old.split("\n"),
-        content_new.split("\n"),
+        content_old.splitlines(True),
+        content_new.splitlines(True),
         fromfile=filename,
         tofile=_("<blockwart content>"),
     ):
-        line += "\n"
         if line.startswith("+"):
             line = green(line)
         elif line.startswith("-"):


### PR DESCRIPTION
Before:

```
--- /tmp/foo

+++ <blockwart content>

@@ -1,2 +1,2 @@

...
```

After:

```
--- /tmp/foo
+++ <blockwart content>
@@ -1 +1 @@
...
```

(Line numbers were off by one, too, but nobody reads them anyway.)
