### PR TITLE
No STDIN for workers when not running interactively

### DIFF
--- a/src/blockwart/cmdline/apply.py
+++ b/src/blockwart/cmdline/apply.py
@@ -37,7 +37,8 @@ def format_node_result(result):
 def bw_apply(repo, args):
     target_nodes = get_target_nodes(repo, args.target)
     worker_count = 1 if args.interactive else args.node_workers
-    with WorkerPool(workers=worker_count) as worker_pool:
+    with WorkerPool(workers=worker_count, interactive=args.interactive) \
+            as worker_pool:
         results = {}
         while (
                 target_nodes or

--- a/src/blockwart/node.py
+++ b/src/blockwart/node.py
@@ -93,7 +93,7 @@ def inject_dummy_items(items):
 
 def apply_items(items, workers=1, interactive=False):
     items = inject_dummy_items(items)
-    with WorkerPool(workers=workers) as worker_pool:
+    with WorkerPool(workers=workers, interactive=interactive) as worker_pool:
         items_with_deps, items_without_deps = \
             split_items_without_deps(items)
         # there are three things we want to do continuously:

--- a/tests/unit/concurrency_tests.py
+++ b/tests/unit/concurrency_tests.py
@@ -178,7 +178,7 @@ class WorkerPoolTest(TestCase):
 
     def test_get_idle_worker(self):
         class MockWorker(object):
-            def __init__(self):
+            def __init__(self, interactive=False):
                 self.busy_counter = 0
                 self.is_reapable = False
                 self.result = None


### PR DESCRIPTION
When creating a pool with more than one worker, it doesn't make sense to
dup() STDIN to all these workers. Suppose there's four workers and all
of them want to read from STDIN -- who gets the input?

As a side effect, without this commit, terminals on Linux are "broken"
after a parallel "bw apply": echoing is turned off after bw has exited.
(Needs a "stty echo" or "reset" to get the terminal back.)
