### PR TITLE
Automatic dependencies between files, symlinks and directories

### DIFF
--- a/src/blockwart/cmdline/repo.py
+++ b/src/blockwart/cmdline/repo.py
@@ -71,6 +71,7 @@ def bw_repo_plot(repo, args):
     items = list(node.items)
 
     for item in items:
+        item._check_bundle_collisions(items)
         # merge static and user-defined deps
         item._deps = list(item.DEPENDS_STATIC)
         item._deps += item.depends

--- a/src/blockwart/items/__init__.py
+++ b/src/blockwart/items/__init__.py
@@ -109,6 +109,19 @@ class Item(object):
     def __repr__(self):
         return "<Item {}>".format(self.id)
 
+    def _check_bundle_collisions(self, items):
+        for item in items:
+            if item == self:
+                continue
+            if item.id == self.id:
+                raise BundleError(_(
+                    "duplicate definition of {} in bundles '{}' and '{}'"
+                ).format(
+                    item.id,
+                    item.bundle.name,
+                    self.bundle.name,
+                ))
+
     def _validate_attribute_names(self, attributes):
         invalid_attributes = set(attributes.keys()).difference(
             set(self.ITEM_ATTRIBUTES.keys()).union(

--- a/src/blockwart/items/directories.py
+++ b/src/blockwart/items/directories.py
@@ -149,7 +149,7 @@ class Directory(Item):
                 )
                 or
                 (
-                    item.ITEM_TYPE_NAME in ("directory", "file", "symlink") and
+                    item.ITEM_TYPE_NAME in ("file", "symlink") and
                     item.name == self.name
                 )
             ):

--- a/src/blockwart/items/files.py
+++ b/src/blockwart/items/files.py
@@ -305,12 +305,7 @@ class File(Item):
     def get_auto_deps(self, items):
         deps = []
         for item in items:
-            if item == self:
-                continue
-            if item.ITEM_TYPE_NAME == "file" and (
-                is_subdirectory(item.name, self.name) or
-                item.name == self.name
-            ):
+            if item.ITEM_TYPE_NAME == "file" and is_subdirectory(item.name, self.name):
                 raise BundleError(_(
                     "{} (from bundle '{}') blocking path to "
                     "{} (from bundle '{}')"

--- a/src/blockwart/items/symlinks.py
+++ b/src/blockwart/items/symlinks.py
@@ -108,16 +108,9 @@ class Symlink(Item):
         for item in items:
             if item == self:
                 continue
-            if (
-                (
-                    item.ITEM_TYPE_NAME == "file" and
-                    is_subdirectory(item.name, self.name)
-                )
-                or
-                (
-                    item.ITEM_TYPE_NAME in ("file", "symlink") and
-                    item.name == self.name
-                )
+            if item.ITEM_TYPE_NAME == "file" and (
+                is_subdirectory(item.name, self.name) or
+                item.name == self.name
             ):
                 raise BundleError(_(
                     "{} (from bundle '{}') blocking path to "

--- a/src/blockwart/node.py
+++ b/src/blockwart/node.py
@@ -222,6 +222,7 @@ def apply_items(items, workers=1, interactive=False):
     items = list(items)
 
     for item in items:
+        item._check_bundle_collisions(items)
         # merge static and user-defined deps
         item._deps = list(item.DEPENDS_STATIC)
         item._deps += item.depends

--- a/tests/unit/items/directories_tests.py
+++ b/tests/unit/items/directories_tests.py
@@ -121,19 +121,6 @@ class DirectoryGetAutoDepsTest(TestCase):
     """
     Tests blockwart.items.directories.Directory.get_auto_deps.
     """
-    def test_directory_collision(self):
-        item1 = MagicMock()
-        item1.ITEM_TYPE_NAME = "directory"
-        item1.id = "directory:/foo/bar/baz"
-        item1.name = "/foo/bar/baz"
-
-        d = directories.Directory(MagicMock(), "/foo/bar/baz", {})
-
-        items = [item1, d]
-
-        with self.assertRaises(BundleError):
-            d.get_auto_deps(items)
-
     def test_file_collision(self):
         item1 = MagicMock()
         item1.ITEM_TYPE_NAME = "file"

--- a/tests/unit/items/files_tests.py
+++ b/tests/unit/items/files_tests.py
@@ -333,19 +333,6 @@ class FileGetAutoDepsTest(TestCase):
     """
     Tests blockwart.items.files.File.get_auto_deps.
     """
-    def test_file_collision(self):
-        item1 = MagicMock()
-        item1.ITEM_TYPE_NAME = "file"
-        item1.id = "file:/foo/bar/baz"
-        item1.name = "/foo/bar/baz"
-
-        f = files.File(MagicMock(), "/foo/bar/baz", {})
-
-        items = [item1, f]
-
-        with self.assertRaises(BundleError):
-            f.get_auto_deps(items)
-
     def test_subdir(self):
         item1 = MagicMock()
         item1.ITEM_TYPE_NAME = "directory"

--- a/tests/unit/items/item_tests.py
+++ b/tests/unit/items/item_tests.py
@@ -143,3 +143,19 @@ class InitTest(TestCase):
 
         i = MyItem(MagicMock(), MagicMock(), {'foo': 49})
         self.assertEqual(i.attributes, {'foo': 49, 'bar': 48})
+
+
+class BundleCollisionTest(TestCase):
+    """
+    Tests blockwart.items.__init__.Item._check_bundle_collisions.
+    """
+    def test_collision(self):
+        item1 = MockItem(MagicMock(), "item1", {}, skip_validation=True)
+        item2 = MockItem(MagicMock(), "item1", {}, skip_validation=True)
+        with self.assertRaises(BundleError):
+            item1._check_bundle_collisions([item1, item2])
+
+    def test_no_collision(self):
+        item1 = MockItem(MagicMock(), "item1", {}, skip_validation=True)
+        item2 = MockItem(MagicMock(), "item2", {}, skip_validation=True)
+        item1._check_bundle_collisions([item1, item2])

--- a/tests/unit/items/symlinks_tests.py
+++ b/tests/unit/items/symlinks_tests.py
@@ -139,19 +139,6 @@ class SymlinkGetAutoDepsTest(TestCase):
 
         self.assertEqual(s.get_auto_deps(items), ["symlink:/foo/bar"])
 
-    def test_symlink_collision(self):
-        item1 = MagicMock()
-        item1.ITEM_TYPE_NAME = "symlink"
-        item1.id = "symlink:/foo/bar/baz"
-        item1.name = "/foo/bar/baz"
-
-        s = symlinks.Symlink(MagicMock(), "/foo/bar/baz", {'target': "/404"})
-
-        items = [item1, s]
-
-        with self.assertRaises(BundleError):
-            s.get_auto_deps(items)
-
 
 class SymlinkGetStatusTest(TestCase):
     """


### PR DESCRIPTION
This should resolve #63. It also has the benefit of detecting collisions from defining files, symlinks or directories at the same path or defining a file to reside at a parent path to a directory, symlink or other file.

Note that this also obsoletes the static dependency of all files on all directories.
