### PR TITLE
Move set_up_logging to the front (#130).

### DIFF
--- a/src/bundlewrap/cmdline/__init__.py
+++ b/src/bundlewrap/cmdline/__init__.py
@@ -53,6 +53,8 @@ def set_up_logging(debug=False, interactive=False):
         format = "%(message)s"
         level = logging.INFO
 
+    logging.basicConfig(format=format, level=logging.ERROR)
+
     formatter = logging.Formatter(format)
 
     handler = FilteringHandler()


### PR DESCRIPTION
When the repo is instantiated, custom cmdb code might use logging,
so logging should already be configured. This at least seems to fix the second point of #130.
