### PR TITLE
Reusability: Move fabric setup to main method.

### DIFF
--- a/src/bundlewrap/cmdline/__init__.py
+++ b/src/bundlewrap/cmdline/__init__.py
@@ -8,9 +8,9 @@ import re
 from sys import argv, exit, stderr, stdout
 
 from fabric.network import disconnect_all
-from fabric.state import env, output
 
 from ..exceptions import NoSuchRepository
+from ..operations import set_up_fabric
 from ..repo import Repository
 from ..utils.text import mark_for_translation as _, red
 from .parser import build_parser_bw
@@ -68,14 +68,6 @@ def set_up_logging(debug=False, interactive=False):
 
     logging.getLogger('paramiko').setLevel(logging.ERROR)
     logging.getLogger('passlib').setLevel(logging.ERROR)
-
-
-def set_up_fabric():
-    env.use_ssh_config = True
-    env.warn_only = True
-    # silence fabric
-    for key in output:
-        output[key] = False
 
 
 def main(*args):

--- a/src/bundlewrap/operations.py
+++ b/src/bundlewrap/operations.py
@@ -15,6 +15,17 @@ from .utils.text import mark_for_translation as _, randstr
 from .utils.ui import LineBuffer
 
 
+def set_up_fabric():
+    """
+    Setup fabric.
+    """
+    env.use_ssh_config = True
+    env.warn_only = True
+    # silence fabric
+    for key in output:
+        output[key] = False
+
+
 class FabricOutput(object):
     def __init__(self, silent=False):
         self.silent = silent


### PR DESCRIPTION
Because fabric is silenced during module import, when importing bundlewrap
from fabric all output via abort or warn is gone.

By moving the setup of fabric to bw's main method, only when using bw directly
via the CLI this will happen, so for pure users of bw nothing should change.
