### PR TITLE
Only use bundlewrap's handler while logging. (#130)

### DIFF
--- a/src/bundlewrap/cmdline/__init__.py
+++ b/src/bundlewrap/cmdline/__init__.py
@@ -63,7 +63,6 @@ def set_up_logging(debug=False, interactive=False):
     root.addHandler(handler)
 
     logger = logging.getLogger('bundlewrap')
-    logger.addHandler(handler)
     logger.setLevel(level)
 
     logging.getLogger('paramiko').setLevel(logging.ERROR)


### PR DESCRIPTION
When calling `logging.basicConfig`, a first handler is established,
usually with the default format (`logging.BASIC_FORMAT`).

The format was overridden, but the handler still exists. Now by
attaching bw's handler to the root logger, exactly one handler
should be used throughout bw. #130 
