### PR TITLE
Fix: Don't crash if a user's 'groups' is None

### DIFF
--- a/src/bundlewrap/items/users.py
+++ b/src/bundlewrap/items/users.py
@@ -111,7 +111,10 @@ class User(Item):
         if self.attributes['delete']:
             return {}
         cdict = self.attributes.copy()
-        cdict['groups'] = set(cdict['groups'])
+        if cdict['groups'] is None:
+            cdict['groups'] = None
+        else:
+            cdict['groups'] = set(cdict['groups'])
         del cdict['delete']
         del cdict['hash_method']
         del cdict['password']


### PR DESCRIPTION
Not quite sure: Is `None` appropriate here? Or should it be deleted?