### PR TITLE
Replace U2503 with U2502

### DIFF
--- a/bundlewrap/utils/text.py
+++ b/bundlewrap/utils/text.py
@@ -137,10 +137,10 @@ def validate_name(name):
 def wrap_question(title, body, question, prefix=""):
     output = ("{0}\n"
               "{0} ╭ {1}\n"
-              "{0} ┃\n".format(prefix, title))
+              "{0} │\n".format(prefix, title))
     for line in body.splitlines():
-        output += "{0} ┃  {1}\n".format(prefix, line)
-    output += ("{0} ┃\n"
+        output += "{0} │  {1}\n".format(prefix, line)
+    output += ("{0} │\n"
                "{0} ╰ ".format(prefix) + question)
     return output
 

--- a/docs/content/guide/quickstart.md
+++ b/docs/content/guide/quickstart.md
@@ -113,14 +113,14 @@ BundleWrap will ask to replace your previous MOTD:
 <pre><code class="nohighlight">i node-1 run started at 2016-02-13 21:25:45
 ? node-1
 ? node-1  ╭ file:/etc/motd
-? node-1  ┃
-? node-1  ┃  content
-? node-1  ┃  --- &lt;node&gt;
-? node-1  ┃  +++ &lt;bundlewrap&gt;
-? node-1  ┃  @@ -1 +1 @@
-? node-1  ┃  -your old motd
-? node-1  ┃  +Welcome to node-1!
-? node-1  ┃
+? node-1  │
+? node-1  │  content
+? node-1  │  --- &lt;node&gt;
+? node-1  │  +++ &lt;bundlewrap&gt;
+? node-1  │  @@ -1 +1 @@
+? node-1  │  -your old motd
+? node-1  │  +Welcome to node-1!
+? node-1  │
 ? node-1  ╰ Fix file:/etc/motd? [Y/n]
 </code></pre>
 


### PR DESCRIPTION
According to Unicode [0], the arcs (U256D and U2570) are "light",
whereas the vertical bar (U2503) is "heavy". This doesn't match. We
should use the light vertical bar (U2502) instead.

[0]: http://www.unicode.org/charts/PDF/U2500.pdf