### PR TITLE
doc: Add documentation about environment variables

### DIFF
--- a/bundlewrap/cmdline/__init__.py
+++ b/bundlewrap/cmdline/__init__.py
@@ -96,7 +96,16 @@ def main(*args, **kwargs):
 
     io.activate_as_parent(debug=pargs.debug)
 
-    environ.setdefault('BWADDHOSTKEYS', "1" if pargs.add_ssh_host_keys else "0")
+    if 'BWADDHOSTKEYS' in environ:  # TODO remove in 3.0.0
+        environ.setdefault('BW_ADD_HOST_KEYS', environ['BWADDHOSTKEYS'])
+    if 'BWCOLORS' in environ:  # TODO remove in 3.0.0
+        environ.setdefault('BW_COLORS', environ['BWCOLORS'])
+    if 'BWITEMWORKERS' in environ:  # TODO remove in 3.0.0
+        environ.setdefault('BW_ITEM_WORKERS', environ['BWITEMWORKERS'])
+    if 'BWNODEWORKERS' in environ:  # TODO remove in 3.0.0
+        environ.setdefault('BW_NODE_WORKERS', environ['BWNODEWORKERS'])
+
+    environ.setdefault('BW_ADD_HOST_KEYS', "1" if pargs.add_ssh_host_keys else "0")
 
     if len(text_args) >= 1 and (
         text_args[0] == "--version" or

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -514,7 +514,7 @@ class Node(object):
             self.hostname,
             remote_path,
             local_path,
-            add_host_keys=True if environ.get('BWADDHOSTKEYS', False) == "1" else False,
+            add_host_keys=True if environ.get('BW_ADD_HOST_KEYS', False) == "1" else False,
         )
 
     def get_item(self, item_id):
@@ -600,7 +600,7 @@ class Node(object):
             self.hostname,
             command,
             ignore_failure=may_fail,
-            add_host_keys=True if environ.get('BWADDHOSTKEYS', False) == "1" else False,
+            add_host_keys=True if environ.get('BW_ADD_HOST_KEYS', False) == "1" else False,
             log_function=log_function,
         )
 
@@ -619,7 +619,7 @@ class Node(object):
             mode=mode,
             owner=owner,
             group=group,
-            add_host_keys=True if environ.get('BWADDHOSTKEYS', False) == "1" else False,
+            add_host_keys=True if environ.get('BW_ADD_HOST_KEYS', False) == "1" else False,
         )
 
     def verify(self, show_all=False, workers=4):
@@ -689,7 +689,7 @@ class NodeLock(object):
                 with open(local_path, 'w') as f:
                     f.write(json.dumps({
                         'date': time(),
-                        'user': environ.get('BWIDENTITY', "{}@{}".format(
+                        'user': environ.get('BW_IDENTITY', "{}@{}".format(
                             getuser(),
                             gethostname(),
                         )),

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -689,7 +689,7 @@ class NodeLock(object):
                 with open(local_path, 'w') as f:
                     f.write(json.dumps({
                         'date': time(),
-                        'user': environ.get('BW_IDENTITY', "{}@{}".format(
+                        'user': environ.get('BWIDENTITY', "{}@{}".format(
                             getuser(),
                             gethostname(),
                         )),

--- a/bundlewrap/utils/text.py
+++ b/bundlewrap/utils/text.py
@@ -16,7 +16,7 @@ VALID_NAME_CHARS = digits + ascii_letters + "-_.+"
 
 
 def ansi_wrapper(colorizer):
-    if environ.get("BWCOLORS", "1") != "0":
+    if environ.get("BW_COLORS", "1") != "0":
         return colorizer
     else:
         return lambda s, **kwargs: s

--- a/bundlewrap/utils/ui.py
+++ b/bundlewrap/utils/ui.py
@@ -38,7 +38,7 @@ def clear_formatting(f):
     """
     @wraps(f)
     def wrapped(self, msg, **kwargs):
-        if TTY and os.environ.get("BWCOLORS", "1") != "0":
+        if TTY and os.environ.get("BW_COLORS", "1") != "0":
             msg = "\033[0m" + msg
         return f(self, msg, **kwargs)
     return wrapped

--- a/docs/content/guide/env.md
+++ b/docs/content/guide/env.md
@@ -1,16 +1,23 @@
 # Environment Variables
 
-## `BW_COLORS`
-
-Colors are enabled by default. Setting this variable to `0` tells BundleWrap to never use any ANSI color escape sequences.
-
 ## `BW_ADD_HOST_KEYS`
 
 As BundleWrap uses OpenSSH to connect to hosts, host key checking is involved. By default, strict host key checking is activated. This might not be suitable for your setup. You can set this variable to `1` to cause BundleWrap to set the OpenSSH option `StrictHostKeyChecking=no`.
 
 You can also use `bw -a ...` to achieve the same effect.
 
-## `BW_NODE_WORKERS` and `BW_ITEM_WORKERS`
+
+## `BW_COLORS`
+
+Colors are enabled by default. Setting this variable to `0` tells BundleWrap to never use any ANSI color escape sequences.
+
+
+## `BW_IDENTITY`
+
+When BundleWrap locks a node, it stores a short description about "you". By default, this is the string `$USER@$HOSTNAME`, e.g. `john@mymachine`. You can use `BW_IDENTITY` to specify a custom string. (No variables will be evaluated in user supplied strings.)
+
+
+## `BW_ITEM_WORKERS` and `BW_NODE_WORKERS`
 
 BundleWrap attempts to parallelize work. These two options specify the number of nodes and items, respectively, which will be handled concurrently. To be more precise, when setting `BW_NODE_WORKERS=8` and `BW_ITEM_WORKERS=2`, BundleWrap will work on eight nodes in parallel, each handling two items in parallel.
 
@@ -19,7 +26,3 @@ You can also use the command line options `-p` and `-P`, e.g. `bw apply -p ... -
 There is no single default for these values. For example, when running `bw apply`, four nodes are being handled by default. However, when running `bw test`, only one node will be tested by default. `BW_NODE_WORKERS` and `BW_ITEM_WORKERS` apply to *all* these operations.
 
 Note that you should not set these variables to very high values. First, it can cause high memory consumption on your machine. Second, not all SSH servers can handle massive parallelism. Please refer to your OpenSSH documentation on how to tune your servers for these situations.
-
-## `BW_IDENTITY`
-
-When BundleWrap locks a node, it stores a short description about "you". By default, this is the string `$USER@$HOSTNAME`, e.g. `john@mymachine`. You can use `BW_IDENTITY` to specify a custom string. (No variables will be evaluated in user supplied strings.)

--- a/docs/content/guide/env.md
+++ b/docs/content/guide/env.md
@@ -1,0 +1,25 @@
+# Environment Variables
+
+## `BWCOLORS`
+
+Colors are enabled by default. Setting this variable to `0` tells BundleWrap to never use any ANSI color escape sequences.
+
+## `BWADDHOSTKEYS`
+
+As BundleWrap uses OpenSSH to connect to hosts, host key checking is involved. By default, strict host key checking is activated. This might not be suitable for your setup. You can set this variable to `1` to cause BundleWrap to set the OpenSSH option `StrictHostKeyChecking=no`.
+
+You can also use `bw -a ...` to achieve the same effect.
+
+## `BWNODEWORKERS` and `BWITEMWORKERS`
+
+BundleWrap attempts to parallelize work. These two options specify the number of nodes and items, respectively, which will be handled concurrently. To be more precise, when setting `BWNODEWORKERS=8` and `BWITEMWORKERS=2`, BundleWrap will work on eight nodes in parallel, each handling two items in parallel.
+
+You can also use the command line options `-p` and `-P`, e.g. `bw apply -p ... -P ... ...`, to achieve the same effect. Command line arguments override environment variables.
+
+There is no single default for these values. For example, when running `bw apply`, four nodes are being handled by default. However, when running `bw test`, only one node will be tested by default. `BWNODEWORKERS` and `BWITEMWORKERS` apply to *all* these operations.
+
+Note that you should not set these variables to very high values. First, it can cause high memory consumption on your machine. Second, not all SSH servers can handle massive parallelism. Please refer to your OpenSSH documentation on how to tune your servers for these situations.
+
+## `BWIDENTITY`
+
+When BundleWrap locks a node, it stores a short description about "you". By default, this is the string `$USER@$HOSTNAME`, e.g. `john@mymachine`. You can use `BWIDENTITY` to specify a custom string. (No variables will be evaluated in user supplied strings.)

--- a/docs/content/guide/env.md
+++ b/docs/content/guide/env.md
@@ -1,25 +1,25 @@
 # Environment Variables
 
-## `BWCOLORS`
+## `BW_COLORS`
 
 Colors are enabled by default. Setting this variable to `0` tells BundleWrap to never use any ANSI color escape sequences.
 
-## `BWADDHOSTKEYS`
+## `BW_ADD_HOST_KEYS`
 
 As BundleWrap uses OpenSSH to connect to hosts, host key checking is involved. By default, strict host key checking is activated. This might not be suitable for your setup. You can set this variable to `1` to cause BundleWrap to set the OpenSSH option `StrictHostKeyChecking=no`.
 
 You can also use `bw -a ...` to achieve the same effect.
 
-## `BWNODEWORKERS` and `BWITEMWORKERS`
+## `BW_NODE_WORKERS` and `BW_ITEM_WORKERS`
 
-BundleWrap attempts to parallelize work. These two options specify the number of nodes and items, respectively, which will be handled concurrently. To be more precise, when setting `BWNODEWORKERS=8` and `BWITEMWORKERS=2`, BundleWrap will work on eight nodes in parallel, each handling two items in parallel.
+BundleWrap attempts to parallelize work. These two options specify the number of nodes and items, respectively, which will be handled concurrently. To be more precise, when setting `BW_NODE_WORKERS=8` and `BW_ITEM_WORKERS=2`, BundleWrap will work on eight nodes in parallel, each handling two items in parallel.
 
 You can also use the command line options `-p` and `-P`, e.g. `bw apply -p ... -P ... ...`, to achieve the same effect. Command line arguments override environment variables.
 
-There is no single default for these values. For example, when running `bw apply`, four nodes are being handled by default. However, when running `bw test`, only one node will be tested by default. `BWNODEWORKERS` and `BWITEMWORKERS` apply to *all* these operations.
+There is no single default for these values. For example, when running `bw apply`, four nodes are being handled by default. However, when running `bw test`, only one node will be tested by default. `BW_NODE_WORKERS` and `BW_ITEM_WORKERS` apply to *all* these operations.
 
 Note that you should not set these variables to very high values. First, it can cause high memory consumption on your machine. Second, not all SSH servers can handle massive parallelism. Please refer to your OpenSSH documentation on how to tune your servers for these situations.
 
-## `BWIDENTITY`
+## `BW_IDENTITY`
 
-When BundleWrap locks a node, it stores a short description about "you". By default, this is the string `$USER@$HOSTNAME`, e.g. `john@mymachine`. You can use `BWIDENTITY` to specify a custom string. (No variables will be evaluated in user supplied strings.)
+When BundleWrap locks a node, it stores a short description about "you". By default, this is the string `$USER@$HOSTNAME`, e.g. `john@mymachine`. You can use `BW_IDENTITY` to specify a custom string. (No variables will be evaluated in user supplied strings.)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,6 +12,7 @@ pages:
   - Quickstart: guide/quickstart.md
   - Installation: guide/installation.md
   - CLI: guide/cli.md
+  - Environment Variables: guide/env.md
   - File templates: guide/item_file_templates.md
   - Custom items: guide/dev_item.md
   - Writing plugins: guide/dev_plugin.md


### PR DESCRIPTION
Yes, we should eliminate the underscore in `BW_IDENTITY`. I didn't want
to introduce a breaking change now, though. Having this documentation is
better than no documentation. :-)