### PR TITLE
Fix `bw test`: Properly ignore DummyItems

### DIFF
--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -730,9 +730,11 @@ def test_items(node, workers=1):
             msg = worker_pool.get_event()
             if msg['msg'] == 'REQUEST_WORK':
                 try:
-                    item = item_queue.pop()
-                    if isinstance(item, DummyItem):
-                        continue
+                    # Get the next non-DummyItem in the queue.
+                    while True:
+                        item = item_queue.pop()
+                        if not isinstance(item, DummyItem):
+                            break
                     worker_pool.start_task(
                         msg['wid'],
                         item.test,


### PR DESCRIPTION
That "continue" is a gnarly beast. Before c53e863, it referred to
another, inner while-loop. That loop was remove by c53e863. This commit
re-introduces it.

This fixes #226.