### PR TITLE
Concurrency makeover

### DIFF
--- a/bundlewrap/bundle.py
+++ b/bundlewrap/bundle.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from copy import copy
 from os.path import exists, join
 
 from .exceptions import NoSuchBundle, RepositoryError
@@ -34,18 +33,6 @@ class Bundle(object):
         self.bundle_data_dir = join(self.repo.data_dir, self.name)
         self.bundle_file = join(self.bundle_dir, FILENAME_BUNDLE)
         self.metadata_file = join(self.bundle_dir, FILENAME_METADATA)
-
-    def __getstate__(self):
-        """
-        Removes cached items prior to pickling because their classes are
-        loaded dynamically and can't be pickled.
-        """
-        state = copy(self.__dict__)
-        try:
-            del state['_cache']
-        except KeyError:
-            pass
-        return state
 
     @cached_property
     def bundle_attrs(self):

--- a/bundlewrap/cmdline/__init__.py
+++ b/bundlewrap/cmdline/__init__.py
@@ -102,6 +102,7 @@ def main(*args, **kwargs):
         exit(2)
 
     io.debug_mode = pargs.debug
+    io.activate()
 
     if 'BWADDHOSTKEYS' in environ:  # TODO remove in 3.0.0
         environ.setdefault('BW_ADD_HOST_KEYS', environ['BWADDHOSTKEYS'])

--- a/bundlewrap/cmdline/__init__.py
+++ b/bundlewrap/cmdline/__init__.py
@@ -101,7 +101,7 @@ def main(*args, **kwargs):
         parser_bw.print_help()
         exit(2)
 
-    io.activate_as_parent(debug=pargs.debug)
+    io.debug_mode = pargs.debug
 
     if 'BWADDHOSTKEYS' in environ:  # TODO remove in 3.0.0
         environ.setdefault('BW_ADD_HOST_KEYS', environ['BWADDHOSTKEYS'])

--- a/bundlewrap/cmdline/apply.py
+++ b/bundlewrap/cmdline/apply.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 from ..concurrency import WorkerPool
+from ..exceptions import WorkerException
 from ..utils.cmdline import get_target_nodes
 from ..utils.text import bold
 from ..utils.text import error_summary, mark_for_translation as _
@@ -41,11 +42,15 @@ def bw_apply(repo, args):
 
             try:
                 result = worker_pool.get_result()
-            except Exception as exc:
+            except WorkerException as exc:
+                msg = "{}: {}".format(
+                    exc.kwargs['task_id'],
+                    exc.wrapped_exception,
+                )
                 if args['debug']:
-                    yield exc.traceback
-                yield str(exc)
-                errors.append(str(exc))
+                    yield exc.wrapped_exception.traceback
+                yield msg
+                errors.append(msg)
             else:
                 node_name = result['task_id']
                 if (

--- a/bundlewrap/cmdline/apply.py
+++ b/bundlewrap/cmdline/apply.py
@@ -4,9 +4,8 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 from ..concurrency import WorkerPool
-from ..exceptions import WorkerException
 from ..utils.cmdline import get_target_nodes
-from ..utils.text import bold, red
+from ..utils.text import bold
 from ..utils.text import error_summary, mark_for_translation as _
 
 
@@ -25,58 +24,49 @@ def bw_apply(repo, args):
     start_time = datetime.now()
 
     with WorkerPool(workers=args['node_workers']) as worker_pool:
-        results = {}
-        while worker_pool.keep_running():
+        while pending_nodes or worker_pool.workers_are_running:
+            while pending_nodes and worker_pool.workers_are_available:
+                node = pending_nodes.pop()
+                worker_pool.start_task(
+                    node.apply,
+                    task_id=node.name,
+                    kwargs={
+                        'autoskip_selector': args['autoskip'],
+                        'force': args['force'],
+                        'interactive': args['interactive'],
+                        'workers': args['item_workers'],
+                        'profiling': args['profiling'],
+                    },
+                )
+
             try:
-                msg = worker_pool.get_event()
-            except WorkerException as e:
-                msg = "{} {}".format(red("!"), e.wrapped_exception)
+                result = worker_pool.get_result()
+            except Exception as exc:
                 if args['debug']:
-                    yield e.traceback
-                if not args['interactive']:
-                    msg = "{}: {}".format(e.task_id, msg)
-                yield msg
-                errors.append(msg)
-                continue
-            if msg['msg'] == 'REQUEST_WORK':
-                if pending_nodes:
-                    node = pending_nodes.pop()
-
-                    worker_pool.start_task(
-                        msg['wid'],
-                        node.apply,
-                        task_id=node.name,
-                        kwargs={
-                            'autoskip_selector': args['autoskip'],
-                            'force': args['force'],
-                            'interactive': args['interactive'],
-                            'workers': args['item_workers'],
-                            'profiling': args['profiling'],
-                        },
-                    )
-                else:
-                    worker_pool.quit(msg['wid'])
-            elif msg['msg'] == 'FINISHED_WORK':
-                node_name = msg['task_id']
-                if msg['return_value'] is not None:  # node skipped because it had no items
-                    results[node_name] = msg['return_value']
-
-                    if args['profiling']:
-                        total_time = 0.0
-                        yield _("  {}").format(bold(node_name))
-                        yield _("  {} BEGIN PROFILING DATA "
-                                "(most expensive items first)").format(bold(node_name))
-                        yield _("  {}    seconds   item").format(bold(node_name))
-                        for time_elapsed, item_id in results[node_name].profiling_info:
-                            yield "  {} {:10.3f}   {}".format(
-                                bold(node_name),
-                                time_elapsed.total_seconds(),
-                                item_id,
-                            )
-                            total_time += time_elapsed.total_seconds()
-                        yield _("  {} {:10.3f}   (total)").format(bold(node_name), total_time)
-                        yield _("  {} END PROFILING DATA").format(bold(node_name))
-                        yield _("  {}").format(bold(node_name))
+                    yield exc.traceback
+                yield str(exc)
+                errors.append(str(exc))
+            else:
+                node_name = result['task_id']
+                if (
+                    result['return_value'] is not None and  # node skipped because it had no items
+                    args['profiling']
+                ):
+                    total_time = 0.0
+                    yield _("  {}").format(bold(node_name))
+                    yield _("  {} BEGIN PROFILING DATA "
+                            "(most expensive items first)").format(bold(node_name))
+                    yield _("  {}    seconds   item").format(bold(node_name))
+                    for time_elapsed, item_id in result['return_value'].profiling_info:
+                        yield "  {} {:10.3f}   {}".format(
+                            bold(node_name),
+                            time_elapsed.total_seconds(),
+                            item_id,
+                        )
+                        total_time += time_elapsed.total_seconds()
+                    yield _("  {} {:10.3f}   (total)").format(bold(node_name), total_time)
+                    yield _("  {} END PROFILING DATA").format(bold(node_name))
+                    yield _("  {}").format(bold(node_name))
 
     error_summary(errors)
 

--- a/bundlewrap/cmdline/apply.py
+++ b/bundlewrap/cmdline/apply.py
@@ -48,7 +48,8 @@ def bw_apply(repo, args):
                     exc.wrapped_exception,
                 )
                 if args['debug']:
-                    yield exc.wrapped_exception.traceback
+                    yield exc.traceback
+                    yield repr(exc)
                 yield msg
                 errors.append(msg)
             else:

--- a/bundlewrap/cmdline/debug.py
+++ b/bundlewrap/cmdline/debug.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 from code import interact
 
 from .. import VERSION_STRING
-from ..repo import Repository
 from ..utils.text import mark_for_translation as _
+from ..utils.ui import io
 
 
 DEBUG_BANNER = _("BundleWrap {version} interactive repository inspector\n"
@@ -17,7 +17,7 @@ DEBUG_BANNER_NODE = DEBUG_BANNER + "\n" + \
 
 
 def bw_debug(repo, args):
-    repo = Repository(repo.path)
+    io.deactivate()
     if args['node'] is None:
         env = {'repo': repo}
         banner = DEBUG_BANNER

--- a/bundlewrap/cmdline/run.py
+++ b/bundlewrap/cmdline/run.py
@@ -7,7 +7,7 @@ from ..concurrency import WorkerPool
 from ..exceptions import WorkerException
 from ..utils.cmdline import get_target_nodes
 from ..utils.text import mark_for_translation as _
-from ..utils.text import bold, cyan, error_summary, green, red
+from ..utils.text import bold, error_summary, green, red
 
 
 def run_on_node(node, command, may_fail, log_output):
@@ -17,13 +17,12 @@ def run_on_node(node, command, may_fail, log_output):
         command,
     )
 
-    log_fmt = "{x} {node}  {{}}".format(
-        node=bold(node.name),
-        x=cyan("›"),
-    )
-
     start = datetime.now()
-    result = node.run(command, log_fmt=log_fmt)
+    result = node.run(
+        command,
+        may_fail=may_fail,
+        log_output=log_output,
+    )
     end = datetime.now()
     duration = end - start
 

--- a/bundlewrap/cmdline/run.py
+++ b/bundlewrap/cmdline/run.py
@@ -91,7 +91,8 @@ def bw_run(repo, args):
                     exc.wrapped_exception,
                 )
                 if args['debug']:
-                    yield exc.wrapped_exception.traceback
+                    yield exc.traceback
+                    yield repr(exc)
                 yield msg
                 errors.append(msg)
             else:

--- a/bundlewrap/cmdline/run.py
+++ b/bundlewrap/cmdline/run.py
@@ -7,7 +7,7 @@ from ..concurrency import WorkerPool
 from ..exceptions import WorkerException
 from ..utils.cmdline import get_target_nodes
 from ..utils.text import mark_for_translation as _
-from ..utils.text import bold, error_summary, green, red
+from ..utils.text import bold, cyan, error_summary, green, red
 
 
 def run_on_node(node, command, may_fail, log_output):
@@ -17,12 +17,13 @@ def run_on_node(node, command, may_fail, log_output):
         command,
     )
 
-    start = datetime.now()
-    result = node.run(
-        command,
-        may_fail=may_fail,
-        log_output=log_output,
+    log_fmt = "{x} {node}  {{}}".format(
+        node=bold(node.name),
+        x=cyan("›"),
     )
+
+    start = datetime.now()
+    result = node.run(command, log_fmt=log_fmt)
     end = datetime.now()
     duration = end - start
 

--- a/bundlewrap/cmdline/run.py
+++ b/bundlewrap/cmdline/run.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 from ..concurrency import WorkerPool
+from ..exceptions import WorkerException
 from ..utils.cmdline import get_target_nodes
 from ..utils.text import mark_for_translation as _
 from ..utils.text import bold, error_summary, green, red
@@ -84,11 +85,15 @@ def bw_run(repo, args):
 
             try:
                 result = worker_pool.get_result()
-            except Exception as exc:
+            except WorkerException as exc:
+                msg = "{}: {}".format(
+                    exc.kwargs['task_id'],
+                    exc.wrapped_exception,
+                )
                 if args['debug']:
-                    yield exc.traceback
-                yield str(exc)
-                errors.append(str(exc))
+                    yield exc.wrapped_exception.traceback
+                yield msg
+                errors.append(msg)
             else:
                 for line in result['return_value']:
                     yield line

--- a/bundlewrap/cmdline/test.py
+++ b/bundlewrap/cmdline/test.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from copy import copy
 
 from ..concurrency import WorkerPool
+from ..exceptions import WorkerException
 from ..plugins import PluginManager
 from ..utils.cmdline import get_target_nodes
 from ..utils.text import bold, green, mark_for_translation as _, red
@@ -27,7 +28,14 @@ def bw_test(repo, args):
                     },
                 )
 
-            worker_pool.get_result()
+            try:
+                worker_pool.get_result()
+            except WorkerException as exc:
+                yield _("{x} {task}:").format(
+                    x=red("!"),
+                    task=exc.kwargs['task_id'],
+                )
+                raise exc.wrapped_exception
 
     checked_groups = []
     for group in repo.groups:

--- a/bundlewrap/cmdline/test.py
+++ b/bundlewrap/cmdline/test.py
@@ -35,7 +35,9 @@ def bw_test(repo, args):
                     x=red("!"),
                     task=exc.kwargs['task_id'],
                 )
-                raise exc.wrapped_exception
+                yield exc.traceback
+                yield "{}: {}".format(type(exc.wrapped_exception), str(exc.wrapped_exception))
+                exit(1)
 
     checked_groups = []
     for group in repo.groups:

--- a/bundlewrap/cmdline/verify.py
+++ b/bundlewrap/cmdline/verify.py
@@ -85,7 +85,8 @@ def bw_verify(repo, args):
                     exc.wrapped_exception,
                 )
                 if args['debug']:
-                    yield exc.wrapped_exception.traceback
+                    yield exc.traceback
+                    yield repr(exc)
                 yield msg
                 errors.append(msg)
             else:

--- a/bundlewrap/cmdline/verify.py
+++ b/bundlewrap/cmdline/verify.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from ..concurrency import WorkerPool
+from ..exceptions import WorkerException
 from ..utils.cmdline import get_target_nodes
 from ..utils.text import error_summary, mark_for_translation as _
 
@@ -78,11 +79,15 @@ def bw_verify(repo, args):
                 )
             try:
                 result = worker_pool.get_result()
-            except Exception as exc:
+            except WorkerException as exc:
+                msg = "{}: {}".format(
+                    exc.kwargs['task_id'],
+                    exc.wrapped_exception,
+                )
                 if args['debug']:
-                    yield exc.traceback
-                yield str(exc)
-                errors.append(str(exc))
+                    yield exc.wrapped_exception.traceback
+                yield msg
+                errors.append(msg)
             else:
                 node_stats[result['task_id']] = result['return_value']
 

--- a/bundlewrap/concurrency.py
+++ b/bundlewrap/concurrency.py
@@ -68,7 +68,10 @@ class WorkerPool(object):
                 traceback = format_tb(exception.__traceback__)
             except AttributeError:  # Python 2
                 traceback = format_tb(future.exception_info()[1])
-            raise WorkerException(exception, traceback, task_id=task_id, worker_id=worker_id)
+            if isinstance(exception, SystemExit):
+                raise exception
+            else:
+                raise WorkerException(exception, traceback, task_id=task_id, worker_id=worker_id)
         else:
             io.debug(_(
                 "worker pool {pool} delivering result of {task} on worker #{worker}"

--- a/bundlewrap/concurrency.py
+++ b/bundlewrap/concurrency.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 from datetime import datetime
 from random import randint
+from traceback import format_tb
 
 from .exceptions import WorkerException
 from .utils.text import mark_for_translation as _
@@ -63,7 +64,11 @@ class WorkerPool(object):
                 task=task_id,
                 worker=worker_id,
             ))
-            raise WorkerException(exception, task_id=task_id, worker_id=worker_id)
+            try:
+                traceback = format_tb(exception.__traceback__)
+            except AttributeError:  # Python 2
+                traceback = format_tb(future.exception_info()[1])
+            raise WorkerException(exception, traceback, task_id=task_id, worker_id=worker_id)
         else:
             io.debug(_(
                 "worker pool {pool} delivering result of {task} on worker #{worker}"

--- a/bundlewrap/concurrency.py
+++ b/bundlewrap/concurrency.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 from datetime import datetime
 from random import randint
 
+from .exceptions import WorkerException
 from .utils.text import mark_for_translation as _
 from .utils.ui import io
 
@@ -62,7 +63,7 @@ class WorkerPool(object):
                 task=task_id,
                 worker=worker_id,
             ))
-            raise exception
+            raise WorkerException(exception, task_id=task_id, worker_id=worker_id)
         else:
             io.debug(_(
                 "worker pool {pool} delivering result of {task} on worker #{worker}"

--- a/bundlewrap/concurrency.py
+++ b/bundlewrap/concurrency.py
@@ -1,153 +1,85 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 from datetime import datetime
-from inspect import ismethod, isgenerator
-from multiprocessing import Manager, Pipe, Process
-import sys
-from traceback import format_exception
+from random import randint
 
-from .exceptions import WorkerException
-from .utils.text import force_text, mark_for_translation as _
+from .utils.text import mark_for_translation as _
 from .utils.ui import io
 
 JOIN_TIMEOUT = 5  # seconds
 
 
-def _worker_process(wid, messages, pipe, io_params):
-    """
-    This is what actually runs in the child process.
-    """
-    # replace the child logger with one that will send logs back to the
-    # parent process
-    io.activate_as_child(*io_params)
-
-    while True:
-        # These two calls can block for an infinite amount of time. We
-        # request work via the public queue and, eventually, some day,
-        # we might get an answer via our private pipe.
-        messages.put({'msg': 'REQUEST_WORK', 'wid': wid})
-        msg = pipe.recv()
-        if msg['msg'] == 'DIE':
-            return
-        elif msg['msg'] == 'NOOP':
-            pass
-        elif msg['msg'] == 'RUN':
-            exception = None
-            exception_task_id = None
-            return_value = None
-            start = datetime.now()
-            traceback = None
-
-            try:
-                if msg['target_obj'] is None:
-                    target = msg['target']
-                else:
-                    target = getattr(msg['target_obj'], msg['target'])
-
-                return_value = target(*msg['args'], **msg['kwargs'])
-
-                if isgenerator(return_value):
-                    return_value = list(return_value)
-
-            except Exception as e:
-                if isinstance(e, WorkerException):
-                    exception = e.wrapped_exception
-                    exception_task_id = e.task_id
-                else:
-                    exception = force_text(repr(e))
-                    exception_task_id = msg['task_id']
-                traceback = "".join([force_text(line) for line in format_exception(*sys.exc_info())])
-                return_value = None
-
-            messages.put({
-                'duration': datetime.now() - start,
-                'exception': exception,
-                'exception_task_id': exception_task_id,
-                'msg': 'FINISHED_WORK',
-                'return_value': return_value,
-                'task_id': msg['task_id'],
-                'traceback': traceback,
-                'wid': wid,
-            })
-
-
 class WorkerPool(object):
     """
-    Manages a bunch of worker processes.
+    Manages a bunch of worker threads.
     """
-    def __init__(self, workers=4):
+    def __init__(self, pool_id=None, workers=4):
         if workers < 1:
             raise ValueError(_("at least one worker is required"))
 
-        # A "worker" is simply a tuple consisting of a Process object
-        # and our end of a pipe. Each worker is always adressed with
-        # it's "worker id" (wid): That's the index of the tuple in
-        # self.workers.
-        self.workers = []
+        self.number_of_workers = workers
+        self.idle_workers = set(range(self.number_of_workers))
 
-        # Lists of wids. idle_workers are those that are marked
-        # explicitly as idle (don't confuse this with workers that
-        # aren't processing a job right now).
-        self.idle_workers = []
-        self.workers_alive = list(range(workers))
-
-        # We don't need to know *which* worker is currently processing a
-        # job. We only need to know how many there are.
-        self.jobs_open = 0
-
-        # The public message queue. Workers ask for jobs here, report
-        # finished work and log items.
-        # Note: There's (at least) two ways to organize a pool like
-        # this. One is to only open a pipe to each worker. Then, you can
-        # use select() to see which pipe can be read from. Problem is,
-        # this is not really supported by the multiprocessing module;
-        # you have to dig into the internals and that's ugly. So, we go
-        # for another option: A managed queue. Multiple processes can
-        # write to it (all the workers do) and the parent can read from
-        # it. However, this is only feasible when workers must talk to
-        # the parent. The parent can't talk to the workers using this
-        # queue. Thus, we still need a dedicated pipe to each worker
-        # (see below).
-        self.messages = Manager().Queue()
-
-        for i in range(workers):
-            (parent_conn, child_conn) = Pipe()
-            p = Process(target=_worker_process,
-                        args=(i, self.messages, child_conn, io.child_parameters))
-            p.start()
-            self.workers.append((p, parent_conn))
+        self.pool_id = "unnamed_pool_{}".format(randint(1, 99999)) if pool_id is None else pool_id
+        self.pending_futures = {}
 
     def __enter__(self):
+        io.debug(_("spinning up worker pool {pool}").format(pool=self.pool_id))
+        self.executor = ThreadPoolExecutor(max_workers=self.number_of_workers)
         return self
 
     def __exit__(self, type, value, traceback):
-        self.shutdown()
+        io.debug(_("shutting down worker pool {pool}").format(pool=self.pool_id))
+        self.executor.shutdown()
+        io.debug(_("worker pool {pool} has been shut down").format(pool=self.pool_id))
 
-    def get_event(self):
+    def get_result(self):
         """
-        Blocks until a message from a worker is received.
+        Blocks until a result from a worker is received.
         """
-        try:
-            msg = self.messages.get()
-        except EOFError:
-            # TODO investigate why this occurs
-            return {'msg': 'EOF_ERROR'}
-        if msg['msg'] == 'FINISHED_WORK':
-            self.jobs_open -= 1
-            # check for exception in child process and raise it
-            # here in the parent
-            if not msg['traceback'] is None:
-                raise WorkerException(
-                    msg['exception_task_id'],
-                    msg['exception'],
-                    msg['traceback'],
-                )
-        return msg
+        io.debug(_("worker pool {pool} waiting for next task to complete").format(
+            pool=self.pool_id,
+        ))
+        completed, pending = wait(self.pending_futures.keys(), return_when=FIRST_COMPLETED)
+        future = completed.pop()
 
-    def start_task(self, wid, target, task_id=None, args=None, kwargs=None):
+        start_time = self.pending_futures[future]['start_time']
+        task_id = self.pending_futures[future]['task_id']
+        worker_id = self.pending_futures[future]['worker_id']
+
+        del self.pending_futures[future]
+        self.idle_workers.add(worker_id)
+
+        exception = future.exception()
+        if exception:
+            io.debug(_(
+                "exception raised while executing task {task} on worker #{worker} "
+                "of worker pool {pool}"
+            ).format(
+                pool=self.pool_id,
+                task=task_id,
+                worker=worker_id,
+            ))
+            raise exception
+        else:
+            io.debug(_(
+                "worker pool {pool} delivering result of {task} on worker #{worker}"
+            ).format(
+                pool=self.pool_id,
+                task=task_id,
+                worker=worker_id,
+            ))
+            return {
+                'duration': datetime.now() - start_time,
+                'return_value': future.result(),
+                'task_id': task_id,
+                'worker_id': worker_id,
+            }
+
+    def start_task(self, target, task_id=None, args=None, kwargs=None):
         """
-        wid         id of the worker to use
         target      any callable (includes bound methods)
         task_id     something to remember this worker by
         args        list of positional arguments passed to target
@@ -160,75 +92,24 @@ class WorkerPool(object):
         if kwargs is None:
             kwargs = {}
 
-        if ismethod(target):
-            target_obj = target.__self__
-            target = target.__name__
-        else:
-            target_obj = None
+        task_id = "unnamed_task_{}".format(randint(1, 99999)) if task_id is None else task_id
+        worker_id = self.idle_workers.pop()
 
-        (process, pipe) = self.workers[wid]
-        pipe.send({
-            'msg': 'RUN',
+        io.debug(_("worker pool {pool} is starting task {task} on worker #{worker}").format(
+            pool=self.pool_id,
+            task=task_id,
+            worker=worker_id,
+        ))
+        self.pending_futures[self.executor.submit(target, *args, **kwargs)] = {
+            'start_time': datetime.now(),
             'task_id': task_id,
-            'target': target,
-            'target_obj': target_obj,
-            'args': args,
-            'kwargs': kwargs,
-        })
+            'worker_id': worker_id,
+        }
 
-        self.jobs_open += 1
+    @property
+    def workers_are_available(self):
+        return bool(self.idle_workers)
 
-    def mark_idle(self, wid):
-        """
-        Mark a worker as "idle".
-        """
-        # We don't really need to do something here. The worker will
-        # simply keep blocking at his "pipe.read()". Just store his id
-        # so we can answer him later.
-        self.idle_workers.append(wid)
-
-    def quit(self, wid):
-        """
-        Shutdown a worker.
-        """
-        (process, pipe) = self.workers[wid]
-        try:
-            pipe.send({'msg': 'DIE'})
-        except IOError:
-            pass
-        pipe.close()
-        process.join(JOIN_TIMEOUT)
-        if process.is_alive():
-            io.stderr(_(
-                "worker process with PID {pid} didn't join "
-                "within {time} seconds, terminating...").format(
-                    pid=process.pid,
-                    time=JOIN_TIMEOUT,
-                )
-            )
-            process.terminate()
-        self.workers_alive.remove(wid)
-
-    def shutdown(self):
-        """
-        Shutdown all workers.
-        """
-        while self.workers_alive:
-            self.quit(self.workers_alive[0])
-
-    def activate_idle_workers(self):
-        """
-        Tell all idle workers to ask for work again.
-        """
-        for wid in self.idle_workers:
-            # Send a noop to this worker. He will simply ask for new
-            # work again.
-            (process, pipe) = self.workers[wid]
-            pipe.send({'msg': 'NOOP'})
-        self.idle_workers = []
-
-    def keep_running(self):
-        """
-        Returns True if this pool is not ready to die.
-        """
-        return self.jobs_open > 0 or self.workers_alive
+    @property
+    def workers_are_running(self):
+        return bool(self.pending_futures)

--- a/bundlewrap/exceptions.py
+++ b/bundlewrap/exceptions.py
@@ -141,24 +141,6 @@ class UsageException(UnicodeException):
     pass
 
 
-class WorkerException(Exception):
-    """
-    Raised when a worker process has encountered an exception while
-    executing.
-    """
-    def __init__(self, task_id, wrapped_exception, traceback):
-        self.task_id = task_id
-        self.traceback = traceback
-        self.wrapped_exception = wrapped_exception
-
-    def __str__(self):
-        output = "\n\n+----- traceback from worker ------\n|\n"
-        for line in self.traceback.strip().split("\n"):
-            output += "|  {}\n".format(line)
-        output += "|\n+----------------------------------\n"
-        return output
-
-
 class NodeAlreadyLockedException(Exception):
     """
     Raised when a node is already locked during an 'apply' run.

--- a/bundlewrap/exceptions.py
+++ b/bundlewrap/exceptions.py
@@ -146,3 +146,18 @@ class NodeAlreadyLockedException(Exception):
     Raised when a node is already locked during an 'apply' run.
     """
     pass
+
+
+class WorkerException(Exception):
+    """
+    Used by worker threads to wrap their exceptions with additional
+    data.
+    """
+    def __init__(self, wrapped_exception, **kwargs):
+        # avoid nesting WorkerExceptions, just store the original exception
+        if isinstance(wrapped_exception, WorkerException):
+            self.kwargs = wrapped_exception.kwargs
+            self.wrapped_exception = wrapped_exception.wrapped_exception
+        else:
+            self.kwargs = kwargs
+            self.wrapped_exception = wrapped_exception

--- a/bundlewrap/exceptions.py
+++ b/bundlewrap/exceptions.py
@@ -153,11 +153,13 @@ class WorkerException(Exception):
     Used by worker threads to wrap their exceptions with additional
     data.
     """
-    def __init__(self, wrapped_exception, **kwargs):
+    def __init__(self, wrapped_exception, traceback, **kwargs):
         # avoid nesting WorkerExceptions, just store the original exception
         if isinstance(wrapped_exception, WorkerException):
             self.kwargs = wrapped_exception.kwargs
+            self.traceback = wrapped_exception.traceback
             self.wrapped_exception = wrapped_exception.wrapped_exception
         else:
             self.kwargs = kwargs
+            self.traceback = "".join(traceback)
             self.wrapped_exception = wrapped_exception

--- a/bundlewrap/group.py
+++ b/bundlewrap/group.py
@@ -51,17 +51,6 @@ class Group(object):
     def __lt__(self, other):
         return self.name < other.name
 
-    def __getstate__(self):
-        """
-        Removes cached metadata processors prior to pickling because
-        they can't be pickled.
-        """
-        try:
-            del self._cache['metadata_processors']
-        except:
-            pass
-        return self.__dict__
-
     def __repr__(self):
         return "<Group: {}>".format(self.name)
 

--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -28,29 +28,6 @@ BUILTIN_ITEM_ATTRIBUTES = {
     'triggers': [],
     'unless': "",
 }
-ITEM_CLASSES = {}
-ITEM_CLASSES_LOADED = False
-
-
-def unpickle_item_class(
-    class_name,
-    bundle,
-    name,
-    attributes,
-    has_been_triggered,
-    faults_missing_for_attributes,
-):
-    for item_class in bundle.node.repo.item_classes:
-        if item_class.__name__ == class_name:
-            return item_class(
-                bundle,
-                name,
-                attributes,
-                has_been_triggered=has_been_triggered,
-                faults_missing_for_attributes=faults_missing_for_attributes,
-                skip_validation=True,
-            )
-    raise RuntimeError(_("unable to unpickle {cls}").format(cls=class_name))
 
 
 class ItemStatus(object):
@@ -157,22 +134,6 @@ class Item(object):
 
     def __str__(self):
         return self.id
-
-    def __reduce__(self):
-        attrs = copy(self.attributes)
-        for attribute_name in BUILTIN_ITEM_ATTRIBUTES.keys():
-            attrs[attribute_name] = getattr(self, attribute_name)
-        return (
-            unpickle_item_class,
-            (
-                self.__class__.__name__,
-                self.bundle,
-                self.name,
-                attrs,
-                self.has_been_triggered,
-                self._faults_missing_for_attributes,
-            ),
-        )
 
     def __repr__(self):
         return "<Item {}>".format(self.id)

--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -1,5 +1,4 @@
 from copy import copy
-from decimal import Decimal
 
 from .exceptions import RepositoryError
 from .utils import _Atomic, ATOMIC_TYPES, Fault, merge_dict
@@ -16,7 +15,6 @@ except NameError:
 METADATA_TYPES = (
     bool,
     byte_type,
-    Decimal,
     Fault,
     int,
     text_type,

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -27,7 +27,7 @@ from .exceptions import (
 )
 from .itemqueue import ItemQueue, ItemTestQueue
 from .items import Item
-from .metadata import check_for_unsolvable_metadata_key_conflicts
+from .metadata import check_for_unsolvable_metadata_key_conflicts, deepcopy_metadata
 from .utils import cached_property, graph_for_items, merge_dict, names, tempfile
 from .utils.statedict import hash_statedict
 from .utils.text import blue, bold, cyan, green, red, validate_name, wrap_question, yellow
@@ -535,7 +535,7 @@ class Node(object):
                     modified = False
                     for metadata_processor in self.metadata_processors:
                         iterations.setdefault(metadata_processor.__name__, 1)
-                        processed = metadata_processor(self._metadata_so_far.copy())
+                        processed = metadata_processor(deepcopy_metadata(self._metadata_so_far))
                         assert isinstance(processed, dict)
                         if processed != self._metadata_so_far:
                             self._metadata_so_far = processed

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -505,7 +505,8 @@ class Node(object):
     @cached_property
     def metadata(self):
         if not self._compiling_metadata.acquire(False):
-            raise DontCache(self._metadata_so_far)
+            with self._compiling_metadata:
+                return self._metadata_so_far
         try:
             self._metadata_so_far = {}
 
@@ -582,6 +583,10 @@ class Node(object):
         os = 'linux' if os is None else os
 
         return self.OS_ALIASES[os.lower()]
+
+    @property
+    def partial_metadata(self):
+        return self._metadata_so_far
 
     def run(self, command, may_fail=False, log_output=False):
         if log_output:

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -134,7 +134,7 @@ def apply_items(node, autoskip_selector="", workers=1, interactive=False, profil
 
                 worker_pool.start_task(
                     item.apply,
-                    task_id=item.id,
+                    task_id="{}:{}".format(node.name, item.id),
                     kwargs={
                         'autoskip_selector': autoskip_selector,
                         'interactive': interactive,
@@ -145,7 +145,7 @@ def apply_items(node, autoskip_selector="", workers=1, interactive=False, profil
             # becomes available
             result = worker_pool.get_result()
 
-            item_id = result['task_id']
+            item_id = result['task_id'].split(":", 1)[1]
             item = find_item(item_id, item_queue.pending_items)
 
             status_code, changes = result['return_value']

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -118,7 +118,7 @@ def handle_apply_result(node, item, status_code, interactive, changes=None):
 
 
 def apply_items(node, autoskip_selector="", workers=1, interactive=False, profiling=False):
-    with io.job(_("  {node} processing dependencies...").format(node=node.name)):
+    with io.job(_("  {node}  processing dependencies...").format(node=node.name)):
         item_queue = ItemQueue(node.items)
     with WorkerPool(workers=workers) as worker_pool:
         while item_queue.items_without_deps or worker_pool.workers_are_running:

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -118,7 +118,8 @@ def handle_apply_result(node, item, status_code, interactive, changes=None):
 
 
 def apply_items(node, autoskip_selector="", workers=1, interactive=False, profiling=False):
-    item_queue = ItemQueue(node.items)
+    with io.job(_("  {node} processing dependencies...").format(node=node.name)):
+        item_queue = ItemQueue(node.items)
     with WorkerPool(workers=workers) as worker_pool:
         while item_queue.items_without_deps or worker_pool.workers_are_running:
             while item_queue.items_without_deps and worker_pool.workers_are_available:

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -30,8 +30,8 @@ from .items import Item
 from .metadata import check_for_unsolvable_metadata_key_conflicts
 from .utils import cached_property, graph_for_items, merge_dict, names, tempfile
 from .utils.statedict import hash_statedict
-from .utils.text import blue, bold, cyan, green, red, validate_name, wrap_question, yellow
-from .utils.text import force_text, mark_for_translation as _
+from .utils.text import blue, bold, green, red, validate_name, wrap_question, yellow
+from .utils.text import mark_for_translation as _
 from .utils.ui import io
 
 LOCK_PATH = "/tmp/bundlewrap.lock"
@@ -579,20 +579,10 @@ class Node(object):
 
         return self.OS_ALIASES[os.lower()]
 
-    def run(self, command, may_fail=False, log_output=False):
-        if log_output:
-            def log_function(msg):
-                io.stdout("{x} {node}  {msg}".format(
-                    node=bold(self.name),
-                    msg=force_text(msg).rstrip("\n"),
-                    x=cyan("›"),
-                ))
-        else:
-            log_function = None
-
+    def run(self, command, may_fail=False, log_fmt=None):
         add_host_keys = True if environ.get('BW_ADD_HOST_KEYS', False) == "1" else False
 
-        if not self._ssh_conn_established:
+        if log_fmt is None and not self._ssh_conn_established:
             # Sometimes we're opening SSH connections to a node too fast
             # for OpenSSH to establish the ControlMaster socket for the
             # second and following connections to use.
@@ -611,13 +601,20 @@ class Node(object):
                 with self._ssh_first_conn_lock:
                     pass
 
-        return operations.run(
-            self.hostname,
-            command,
-            ignore_failure=may_fail,
-            add_host_keys=add_host_keys,
-            log_function=log_function,
-        )
+        if log_fmt:
+            return operations.run_with_log(
+                self.hostname,
+                command,
+                log_fmt,
+                add_host_keys=add_host_keys,
+            )
+        else:
+            return operations.run(
+                self.hostname,
+                command,
+                ignore_failure=may_fail,
+                add_host_keys=add_host_keys,
+            )
 
     def test(self, workers=4):
         with io.job(_("  {node}  checking for metadata collisions...").format(node=self.name)):

--- a/bundlewrap/operations.py
+++ b/bundlewrap/operations.py
@@ -63,73 +63,10 @@ class RunResult(object):
         return force_text(self.stdout)
 
 
-def run(hostname, command, ignore_failure=False, add_host_keys=False):
+def run(hostname, command, ignore_failure=False, add_host_keys=False, log_function=None):
     """
     Runs a command on a remote system.
     """
-    io.debug("running on {host}: {command}".format(command=command, host=hostname))
-
-    stderr_fd_r, stderr_fd_w = pipe()
-
-    # Launch OpenSSH. It's important that SSH gets a dummy stdin, i.e.
-    # it must *not* read from the terminal. Otherwise, it can steal user
-    # input.
-    ssh_process = Popen(
-        [
-            "ssh",
-            "-o",
-            "StrictHostKeyChecking=no" if add_host_keys else "StrictHostKeyChecking=yes",
-            hostname,
-            "LANG=C sudo bash -c " + quote(command),
-        ],
-        stdin=PIPE,
-        stderr=stderr_fd_w,
-        stdout=PIPE,
-    )
-
-    quit_event = Event()
-    stderr_lb = LineBuffer(None)
-    stderr_thread = Thread(
-        args=(stderr_lb, stderr_fd_r, quit_event),
-        target=output_thread_body,
-    )
-    stderr_thread.start()
-
-    try:
-        stdout, empty_stderr = ssh_process.communicate()
-    finally:
-        quit_event.set()
-        stderr_thread.join()
-        stderr_lb.close()
-        close(stderr_fd_r)
-        close(stderr_fd_w)
-
-    io.debug("command finished with return code {}".format(ssh_process.returncode))
-
-    result = RunResult()
-    result.stdout = stdout
-    result.stderr = stderr_lb.record.getvalue()
-    result.return_code = ssh_process.returncode
-
-    if result.return_code != 0 and (not ignore_failure or result.return_code == 255):
-        raise RemoteException(_(
-            "Non-zero return code ({rcode}) running '{command}' on '{host}':\n\n{result}"
-        ).format(
-            command=command,
-            host=hostname,
-            rcode=result.return_code,
-            result=force_text(result.stdout) + force_text(result.stderr),
-        ))
-    return result
-
-
-def run_with_log(hostname, command, log_fmt, add_host_keys=False):
-    """
-    Runs a command on a remote system.
-    """
-    def log_function(msg):
-        io.stdout(log_fmt.format(force_text(msg).rstrip("\n")))
-
     # LineBuffer objects take care of always printing complete lines
     # which have been properly terminated by a newline. This is only
     # relevant when using "bw run".
@@ -215,6 +152,15 @@ def run_with_log(hostname, command, log_fmt, add_host_keys=False):
     result.stderr = stderr_lb.record.getvalue()
     result.return_code = ssh_process.returncode
 
+    if result.return_code != 0 and (not ignore_failure or result.return_code == 255):
+        raise RemoteException(_(
+            "Non-zero return code ({rcode}) running '{command}' on '{host}':\n\n{result}"
+        ).format(
+            command=command,
+            host=hostname,
+            rcode=result.return_code,
+            result=force_text(result.stdout) + force_text(result.stderr),
+        ))
     return result
 
 

--- a/bundlewrap/operations.py
+++ b/bundlewrap/operations.py
@@ -80,6 +80,7 @@ def run(hostname, command, ignore_failure=False, add_host_keys=False):
             hostname,
             "LANG=C sudo bash -c " + quote(command),
         ],
+        stdin=PIPE,
         stderr=PIPE,
         stdout=PIPE,
     )

--- a/bundlewrap/operations.py
+++ b/bundlewrap/operations.py
@@ -80,7 +80,6 @@ def run(hostname, command, ignore_failure=False, add_host_keys=False):
             hostname,
             "LANG=C sudo bash -c " + quote(command),
         ],
-        stdin=PIPE,
         stderr=PIPE,
         stdout=PIPE,
     )

--- a/bundlewrap/operations.py
+++ b/bundlewrap/operations.py
@@ -102,8 +102,9 @@ def run(hostname, command, ignore_failure=False, add_host_keys=False, log_functi
     ssh_process = Popen(
         [
             "ssh",
-            "-o",
-            "StrictHostKeyChecking=no" if add_host_keys else "StrictHostKeyChecking=yes",
+            "-o", "KbdInteractiveAuthentication=no",
+            "-o", "PasswordAuthentication=no",
+            "-o", "StrictHostKeyChecking=no" if add_host_keys else "StrictHostKeyChecking=yes",
             hostname,
             "LANG=C sudo bash -c " + quote(command),
         ],

--- a/bundlewrap/operations.py
+++ b/bundlewrap/operations.py
@@ -24,6 +24,14 @@ def output_thread_body(line_buffer, read_fd, quit_event, read_until_eof):
             else:  # EOF
                 return
         elif quit_event.is_set() and not read_until_eof:
+            # one last chance to read output after the child process
+            # has died
+            while True:
+                r, w, x = select([read_fd], [], [], 0)
+                if r:
+                    line_buffer.write(read(read_fd, 1024))
+                else:
+                    break
             return
 
 

--- a/bundlewrap/repo.py
+++ b/bundlewrap/repo.py
@@ -150,17 +150,11 @@ class HooksProxy(object):
 
         return self.__hook_cache[event]
 
-    def __getstate__(self):
-        return (self.__path, self.__registered_hooks)
-
-    def __setstate__(self, state):
-        self.__hook_cache = {}
-        self.__module_cache = {}
-        self.__path = state[0]
-        self.__registered_hooks = state[1]
-
     def _register_hooks(self):
         """
+        TODO check if this is still required after getting rid of
+        subprocesses and pickling.
+
         Builds an internal dictionary of defined hooks that is used in
         __getstate__ to avoid reimporting all hook modules in child
         processes.
@@ -242,13 +236,6 @@ class LibsProxy(object):
             self.__module_cache[attrname] = m
         return self.__module_cache[attrname]
 
-    def __getstate__(self):
-        return self.__path
-
-    def __setstate__(self, state):
-        self.__module_cache = {}
-        self.__path = state
-
 
 def nodes_from_file(filepath, libs, repo_path, vault):
     """
@@ -292,21 +279,6 @@ class Repository(object):
             # in-memory repos are never equal
             return False
         return self.path == other.path
-
-    def __getstate__(self):
-        """
-        Removes cached item classes prior to pickling because they are loaded
-        dynamically and can't be pickled.
-        """
-        state = copy(self.__dict__)
-        state['item_classes'] = []
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__ = state
-        self.item_classes = list(items_from_path(items.__path__[0]))
-        if self.path != "/dev/null":
-            self.item_classes += list(items_from_path(self.items_dir))
 
     def __repr__(self):
         return "<Repository at '{}'>".format(self.path)

--- a/bundlewrap/repo.py
+++ b/bundlewrap/repo.py
@@ -131,17 +131,6 @@ class HooksProxy(object):
                 if event in events:
                     files.append(filename)
 
-            # check the cache for the imported function,
-            # import if necessary
-            for filename in files:
-                if filename not in self.__module_cache:
-                    self.__module_cache[filename] = {}
-                    filepath = join(self.__path, filename)
-                    for name, obj in utils.get_all_attrs_from_file(filepath).items():
-                        if name not in HOOK_EVENTS:
-                            continue
-                        self.__module_cache[filename][name] = obj
-
             # define a function that calls all hook functions
             def hook(*args, **kwargs):
                 for filename in files:
@@ -152,19 +141,7 @@ class HooksProxy(object):
 
     def _register_hooks(self):
         """
-        TODO check if this is still required after getting rid of
-        subprocesses and pickling.
-
-        Builds an internal dictionary of defined hooks that is used in
-        __getstate__ to avoid reimporting all hook modules in child
-        processes.
-
-        We have to do this since we cannot pass the imported functions
-        to a child process. The dumb-but-simple approach would be to
-        rediscover hooks in every child process (which might be costly).
-
-        From this dictionary the child process knows which hooks exist
-        and can import them only as needed.
+        Builds an internal dictionary of defined hooks.
 
         Priming __module_cache here is just a performance shortcut and
         could be left out.

--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from codecs import getwriter
 from contextlib import contextmanager
-from copy import deepcopy
 import hashlib
 from inspect import isgenerator
 from os import chmod, close, makedirs, remove
@@ -281,7 +280,7 @@ def merge_dict(base, update):
     if not isinstance(update, dict):
         return update
 
-    merged = deepcopy(base)
+    merged = base.copy()
 
     for key, value in update.items():
         merge = key in base and not isinstance(value, _Atomic)
@@ -296,7 +295,7 @@ def merge_dict(base, update):
                 isinstance(value, tuple)
             )
         ):
-            extended = deepcopy(base[key])
+            extended = base[key][:]
             extended.extend(value)
             merged[key] = extended
         elif (

--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -11,7 +11,6 @@ from os.path import dirname, exists
 import stat
 from sys import stderr, stdout
 from tempfile import mkstemp
-from types import MethodType
 
 from requests import get
 
@@ -29,36 +28,6 @@ try:
 except AttributeError:  # Python 2
     STDERR_WRITER = getwriter('utf-8')(stderr)
     STDOUT_WRITER = getwriter('utf-8')(stdout)
-
-
-# what follows is required to pickle bound instance methods on py2.7
-# see https://travis-ci.org/bundlewrap/bundlewrap/jobs/115654253
-# and http://stackoverflow.com/q/1816958
-def _pickle_method(method):
-    func_name = method.im_func.__name__
-    obj = method.im_self
-    cls = method.im_class
-    if func_name.startswith("__") and not func_name.endswith("__"):
-        cls_name = cls.__name__.lstrip("_")
-        func_name = "_" + cls_name + func_name
-    return _unpickle_method, (func_name, obj, cls)
-
-
-def _unpickle_method(func_name, obj, cls):
-    for cls in cls.mro():
-        try:
-            func = cls.__dict__[func_name]
-        except KeyError:
-            pass
-        else:
-            break
-    return func.__get__(obj, cls)
-
-try:
-    import copy_reg
-    copy_reg.pickle(MethodType, _pickle_method, _unpickle_method)
-except ImportError:  # Python 3
-    pass
 
 
 def cached_property(prop):

--- a/bundlewrap/utils/ui.py
+++ b/bundlewrap/utils/ui.py
@@ -87,7 +87,7 @@ class IOManager(object):
 
     def ask(self, question, default, epilogue=None, input_handler=DrainableStdin()):
         assert self._active
-        answers = _("[Y/n]") if default else _("[y/N]")
+        answers = _("[Y/n/q]") if default else _("[y/N/q]")
         question = question + " " + answers + " "
         with self.lock:
             self._clear_last_job()
@@ -106,6 +106,10 @@ class IOManager(object):
                 ):
                     answer = False
                     break
+                elif answer.lower() in (_("q"), _("quit")):
+                    if epilogue:
+                        write_to_stream(STDOUT_WRITER, epilogue + "\n")
+                    sys.exit(0)
                 write_to_stream(STDOUT_WRITER, _("Please answer with 'y(es)' or 'n(o)'.\n"))
             if epilogue:
                 write_to_stream(STDOUT_WRITER, epilogue + "\n")

--- a/docs/content/guide/dev_item.md
+++ b/docs/content/guide/dev_item.md
@@ -15,7 +15,7 @@ normal Python dictionaries with some restrictions:
 	* None
 * ...or a list/tuple containing only instances of one of the types above
 
-Additional information can be stored in statedicts by using keys that start with an underscore. You may only use this for caching purposes (e.g. storing rendered file template content while the "real" sdict information only contains a hash of this content). BundleWrap will ignore these keys and hide them from the user. The type restrictions noted above do not apply, but everything must be pickleable.
+Additional information can be stored in statedicts by using keys that start with an underscore. You may only use this for caching purposes (e.g. storing rendered file template content while the "real" sdict information only contains a hash of this content). BundleWrap will ignore these keys and hide them from the user. The type restrictions noted above do not apply.
 
 
 ## Step 1: Create an item module

--- a/docs/content/repo/bundles.md
+++ b/docs/content/repo/bundles.md
@@ -271,3 +271,5 @@ These functions take the metadata dictionary generated so far as their single ar
 	def my_metadata_processor(metadata):
 	    metadata["foo"] = node.name
 	    return metadata
+
+<div class="alert alert-danger">To avoid deadlocks when accessing <strong>other</strong> nodes' metadata from within a metadata processor, use <code>other_node.partial_metadata</code> instead of <code>other_node.metadata</code>.</div>

--- a/docs/content/repo/bundles.md
+++ b/docs/content/repo/bundles.md
@@ -272,4 +272,4 @@ These functions take the metadata dictionary generated so far as their single ar
 	    metadata["foo"] = node.name
 	    return metadata
 
-<div class="alert alert-danger">To avoid deadlocks when accessing <strong>other</strong> nodes' metadata from within a metadata processor, use <code>other_node.partial_metadata</code> instead of <code>other_node.metadata</code>.</div>
+<div class="alert alert-danger">To avoid deadlocks when accessing <strong>other</strong> nodes' metadata from within a metadata processor, use <code>other_node.partial_metadata</code> instead of <code>other_node.metadata</code>. For the same reason, always use the <code>metadata</code> parameter to access the current node's metadata, never <code>node.metadata</code>.</div>

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,17 @@
+from sys import version_info
+
 from setuptools import find_packages, setup
 
+
+dependencies = [
+    "cryptography",
+    "Jinja2",
+    "Mako",
+    "passlib",
+    "requests >= 1.0.0",
+]
+if version_info < (3, 2, 0):
+    dependencies.append("futures")
 
 setup(
     name="bundlewrap",
@@ -35,12 +47,9 @@ setup(
         "Topic :: System :: Installation/Setup",
         "Topic :: System :: Systems Administration",
     ],
-    install_requires=[
-        "cryptography",
-        "Jinja2",
-        "Mako",
-        "passlib",
-        "requests >= 1.0.0",
-    ],
+    install_requires=dependencies,
+    extras_require={  # used for wheels
+        ':python_version=="2.7"': ["futures"],
+    },
     zip_safe=False,
 )


### PR DESCRIPTION
This went better than expected. I chose a more traditional approach than asyncio, using Python's GIL-impaired pseudo threads.

Running the same `bw test -p 4 -P 4`:
* current master: 151 seconds, ~2 GB RAM peak
* this branch: 80 seconds, 152 MB RAM peak

Even a big `bw verify` that took 559 seconds on master now completes in just 205 seconds.  

There are a few things left to do:
* handling exceptions (currently there is no way to tell which node caused an exception)
* restoring Python 2.7 compatibility using https://pypi.python.org/pypi/futures
* theres a TODO marker about hook registration that needs investigating