### PR TITLE
Enable/disable services

### DIFF
--- a/docs/content/items/svc_systemd.md
+++ b/docs/content/items/svc_systemd.md
@@ -4,6 +4,7 @@ Handles services managed by systemd.
 
     svc_systemd = {
         "fcron.service": {
+            "enabled": True,
             "running": True,  # default
         },
         "sgopherd.socket": {
@@ -16,6 +17,12 @@ Handles services managed by systemd.
 ## Attribute reference
 
 See also: [The list of generic builtin item attributes](../repo/bundles.md#builtin-item-attributes)
+
+<br>
+
+### enabled
+
+`True` if the service shall be automatically started during system bootup; `False` otherwise. `None`, the default value, makes BundleWrap ignore this setting.
 
 <br>
 


### PR DESCRIPTION
PR for #137. Only systemd for now, so consider this WIP.

Note: This PR is not backwards compatible because the default value for `enabled` is `True`. Hence, when using this with existing repos, all services will automatically be enabled which is not necessarily what the user wants.
