### PR TITLE
operations.run: Fix compound commands

### DIFF
--- a/bundlewrap/operations.py
+++ b/bundlewrap/operations.py
@@ -106,7 +106,7 @@ def run(hostname, command, ignore_failure=False, add_host_keys=False, log_functi
             "-o", "PasswordAuthentication=no",
             "-o", "StrictHostKeyChecking=no" if add_host_keys else "StrictHostKeyChecking=yes",
             hostname,
-            "sudo bash -c " + quote("LANG=C " + command),
+            "sudo bash -c " + quote("export LANG=C; " + command),
         ],
         stdin=PIPE,
         stderr=stderr_fd_w,


### PR DESCRIPTION
7d90557 introduced a bug: "FOO=bar command" only works for simple
commands, but breaks when "command" is a compound command. For example:

    $ bash -c 'FOO=bar echo this is okay'
    this is okay

    $ bash -c 'FOO=bar for i in 1 2; do echo $i; done'
    bash: -c: line 0: syntax error near unexpected token `do'
    bash: -c: line 0: `FOO=bar for i in 1 2; do echo $i; done'

    $ bash -c 'LANG=de_DE.UTF-8 echo this is not okay; date'
    this is not okay
    Tue May 10 13:54:08 CEST 2016

That last one is particularly nasty because it doesn't result in an
error but simply does not use the variable (because it's unset).

Fix this by explicitly using "export".

    $ bash -c 'export FOO=bar; for i in 1 2; do echo $i; done'
    1
    2

    $ bash -c 'export LANG=de_DE.UTF-8; echo now we are fine; date'
    now we are fine
    Di 10. Mai 13:56:41 CEST 2016