### PR TITLE
Don't flush stdin if it's not a TTY

### DIFF
--- a/bundlewrap/utils/ui.py
+++ b/bundlewrap/utils/ui.py
@@ -73,7 +73,8 @@ class DrainableStdin(object):
             return input()
 
     def drain(self):
-        termios.tcflush(sys.stdin, termios.TCIFLUSH)
+        if sys.stdin.isatty():
+            termios.tcflush(sys.stdin, termios.TCIFLUSH)
 
 
 class IOManager(object):


### PR DESCRIPTION
If stdin is not a TTY, we get this error:

    error(25, 'Inappropriate ioctl for device')

This matters for operations like this:

    $ yes n | bw apply -i $node

Why would I do that? To get a "diff" of the node. (Yes, we could
implement this is a new bw command, but I think the "yes" approach is
sufficient.)