### PR TITLE
Use `grep -a` for /etc/passwd on GNU

### DIFF
--- a/bundlewrap/items/users.py
+++ b/bundlewrap/items/users.py
@@ -166,7 +166,7 @@ class User(Item):
         if self.node.os == 'openbsd':
             password_command = "grep -e '^{}:' /etc/master.passwd"
         else:
-            password_command = "grep -e '^{}:' /etc/passwd"
+            password_command = "grep -ae '^{}:' /etc/passwd"
         passwd_grep_result = self.node.run(
             password_command.format(self.name),
             may_fail=True,


### PR DESCRIPTION
The full name ("gecos") of a user might contain non-ASCII characters. On
systems with `LANG=C`, this can lead to grep saying:

    Binary file matches

(Instead of the actual match.)