### PR TITLE
`bw lock show` can accept multiple nodes and groups

### DIFF
--- a/bundlewrap/cmdline/lock.py
+++ b/bundlewrap/cmdline/lock.py
@@ -13,6 +13,7 @@ def bw_lock_add(repo, args):
     errors = []
     target_nodes = get_target_nodes(repo, args['target'])
     pending_nodes = target_nodes[:]
+    max_node_name_length = max([len(node.name) for node in target_nodes])
     lock_id = randstr(length=4).upper()
 
     def tasks_available():
@@ -34,7 +35,7 @@ def bw_lock_add(repo, args):
     def handle_result(task_id, return_value, duration):
         io.stdout(_("{x} {node}  locked with ID {id} (expires in {exp})").format(
             x=green("✓"),
-            node=bold(task_id),
+            node=bold(task_id.ljust(max_node_name_length)),
             id=return_value,
             exp=args['expiry'],
         ))
@@ -63,6 +64,7 @@ def bw_lock_remove(repo, args):
     errors = []
     target_nodes = get_target_nodes(repo, args['target'])
     pending_nodes = target_nodes[:]
+    max_node_name_length = max([len(node.name) for node in target_nodes])
 
     def tasks_available():
         return bool(pending_nodes)
@@ -78,7 +80,7 @@ def bw_lock_remove(repo, args):
     def handle_result(task_id, return_value, duration):
         io.stdout(_("{x} {node}  lock {id} removed").format(
             x=green("✓"),
-            node=bold(task_id),
+            node=bold(task_id.ljust(max_node_name_length)),
             id=args['lock_id'].upper(),
         ))
 
@@ -106,6 +108,7 @@ def bw_lock_show(repo, args):
     errors = []
     target_nodes = get_target_nodes(repo, args['target'])
     pending_nodes = target_nodes[:]
+    max_node_name_length = max([len(node.name) for node in target_nodes])
     locks_on_node = {}
 
     def tasks_available():
@@ -162,7 +165,7 @@ def bw_lock_show(repo, args):
         if not locks:
             io.stdout(_("{x} {node}  no soft locks present").format(
                 x=green("✓"),
-                node=bold(node_name),
+                node=bold(node_name.ljust(max_node_name_length)),
             ))
             previous_node_was_unlocked = True
 
@@ -187,7 +190,7 @@ def bw_lock_show(repo, args):
             lengths = {}
             headline = "{x} {node}  ".format(
                 x=blue("i"),
-                node=bold(node_name),
+                node=bold(node_name.ljust(max_node_name_length)),
             )
 
             for column, title in headers:
@@ -205,7 +208,7 @@ def bw_lock_show(repo, args):
                 for lineno, item_selectors in enumerate(lock['items']):
                     line = "{x} {node}  ".format(
                         x=cyan("›"),
-                        node=bold(node_name),
+                        node=bold(node_name.ljust(max_node_name_length)),
                     )
                     for column, title in headers:
                         if column == 'items':

--- a/bundlewrap/cmdline/lock.py
+++ b/bundlewrap/cmdline/lock.py
@@ -103,19 +103,45 @@ def bw_lock_remove(repo, args):
 
 
 def bw_lock_show(repo, args):
-    node = repo.get_node(args['target'])
-    locks = softlock_list(node)
+    errors = []
+    target_nodes = get_target_nodes(repo, args['target'])
+    pending_nodes = target_nodes[:]
+    locks_on_node = {}
 
-    if not locks:
-        io.stdout(_("{x} {node}  no soft locks present").format(
-            x=green("✓"),
-            node=bold(node.name),
-        ))
+    def tasks_available():
+        return bool(pending_nodes)
+
+    def next_task():
+        node = pending_nodes.pop()
+        return {
+            'target': softlock_list,
+            'task_id': node.name,
+            'args': (node,),
+        }
+
+    def handle_result(task_id, return_value, duration):
+        locks_on_node[task_id] = return_value
+
+    def handle_exception(task_id, exception, traceback):
+        msg = "{}: {}".format(task_id, exception)
+        io.stderr(traceback)
+        io.stderr(repr(exception))
+        io.stderr(msg)
+        errors.append(msg)
+
+    worker_pool = WorkerPool(
+        tasks_available,
+        next_task,
+        handle_exception=handle_exception,
+        handle_result=handle_result,
+        pool_id="lock_show",
+        workers=args['node_workers'],
+    )
+    worker_pool.run()
+
+    if errors:
+        error_summary(errors)
         return
-
-    for lock in locks:
-        lock['formatted_date'] = format_timestamp(lock['date'])
-        lock['formatted_expiry'] = format_timestamp(lock['expiry'])
 
     headers = (
         ('id', _("ID")),
@@ -125,34 +151,69 @@ def bw_lock_show(repo, args):
         ('items', _("Items")),
         ('comment', _("Comment")),
     )
-    lengths = {}
-    headline = "{x} {node}  ".format(
-        x=blue("i"),
-        node=bold(node.name),
-    )
 
-    for column, title in headers:
-        lengths[column] = len(title)
-        for lock in locks:
-            if column == 'items':
-                length = max([len(selector) for selector in lock[column]])
-            else:
-                length = len(lock[column])
-            lengths[column] = max(lengths[column], length)
-        headline += bold(title.ljust(lengths[column] + 2))
+    locked_nodes = 0
+    for node_name, locks in locks_on_node.items():
+        if locks:
+            locked_nodes += 1
 
-    io.stdout(headline.rstrip())
-    for lock in locks:
-        for lineno, item_selectors in enumerate(lock['items']):
-            line = "{x} {node}  ".format(
-                x=cyan("›"),
-                node=bold(node.name),
+    previous_node_was_unlocked = False
+    for node_name, locks in sorted(locks_on_node.items()):
+        if not locks:
+            io.stdout(_("{x} {node}  no soft locks present").format(
+                x=green("✓"),
+                node=bold(node_name),
+            ))
+            previous_node_was_unlocked = True
+
+    output_counter = 0
+    for node_name, locks in sorted(locks_on_node.items()):
+        if locks:
+            # Unlocked nodes are printed without empty lines in
+            # between them. Locked nodes can produce lengthy output,
+            # though, so we add empty lines.
+            if (
+                previous_node_was_unlocked or (
+                    output_counter > 0 and output_counter < locked_nodes
+                )
+            ):
+                previous_node_was_unlocked = False
+                io.stdout('')
+
+            for lock in locks:
+                lock['formatted_date'] = format_timestamp(lock['date'])
+                lock['formatted_expiry'] = format_timestamp(lock['expiry'])
+
+            lengths = {}
+            headline = "{x} {node}  ".format(
+                x=blue("i"),
+                node=bold(node_name),
             )
+
             for column, title in headers:
-                if column == 'items':
-                    line += lock[column][lineno].ljust(lengths[column] + 2)
-                elif lineno == 0:
-                    line += lock[column].ljust(lengths[column] + 2)
-                else:
-                    line += " " * (lengths[column] + 2)
-            io.stdout(line.rstrip())
+                lengths[column] = len(title)
+                for lock in locks:
+                    if column == 'items':
+                        length = max([len(selector) for selector in lock[column]])
+                    else:
+                        length = len(lock[column])
+                    lengths[column] = max(lengths[column], length)
+                headline += bold(title.ljust(lengths[column] + 2))
+
+            io.stdout(headline.rstrip())
+            for lock in locks:
+                for lineno, item_selectors in enumerate(lock['items']):
+                    line = "{x} {node}  ".format(
+                        x=cyan("›"),
+                        node=bold(node_name),
+                    )
+                    for column, title in headers:
+                        if column == 'items':
+                            line += lock[column][lineno].ljust(lengths[column] + 2)
+                        elif lineno == 0:
+                            line += lock[column].ljust(lengths[column] + 2)
+                        else:
+                            line += " " * (lengths[column] + 2)
+                    io.stdout(line.rstrip())
+
+            output_counter += 1

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -323,9 +323,19 @@ def build_parser_bw():
     parser_lock_show.set_defaults(func=bw_lock_show)
     parser_lock_show.add_argument(
         'target',
-        metavar=_("NODE"),
+        metavar=_("NODE1,NODE2,GROUP1,bundle:BUNDLE1..."),
         type=str,
         help=_("target node"),
+    )
+    bw_lock_show_p_default = int(environ.get("BW_NODE_WORKERS", "4"))
+    parser_lock_show.add_argument(
+        "-p",
+        "--parallel-nodes",
+        default=bw_lock_show_p_default,
+        dest='node_workers',
+        help=_("number of nodes to retrieve locks from simultaneously "
+               "(defaults to {})").format(bw_lock_show_p_default),
+        type=int,
     )
 
     # bw metadata


### PR DESCRIPTION
PR for #251.

Output looks like this:

    $ bw lock show megasystems,super,web,bla
    ✓ megasystem1  no soft locks present
    ✓ megasystem2  no soft locks present
    ✓ supersystem  no soft locks present
    ✓ weppserver  no soft locks present

    i loadbalancer  ID    Created              Expires              User                 Items  Comment  
    › loadbalancer  BMYG  2016-06-10 19:19:49  2016-06-10 20:19:49  void@pinguin:master  *

    i databasecluster01  ID    Created              Expires              User                 Items  Comment  
    › databasecluster01  GYRX  2016-06-10 19:15:24  2016-06-10 20:15:24  void@pinguin:master  *

    i mail  ID    Created              Expires              User                 Items   Comment  
    › mail  GYRX  2016-06-10 19:15:24  2016-06-10 20:15:24  anna@pinguin:master  *
    › mail  JUJR  2016-06-10 19:52:39  2016-06-10 20:52:39  void@pinguin:master  user:
    › mail                                                                       group:
