### PR TITLE
drop requirement for bash on nodes

### DIFF
--- a/bundlewrap/operations.py
+++ b/bundlewrap/operations.py
@@ -110,7 +110,7 @@ def run(hostname, command, ignore_failure=False, add_host_keys=False, log_functi
     if extra_args:
         ssh_command.extend(split(extra_args))
     ssh_command.append(hostname)
-    ssh_command.append("sudo bash -c " + quote("export LANG=C; " + command))
+    ssh_command.append("sudo sh -c " + quote("export LANG=C; " + command))
     ssh_process = Popen(
         ssh_command,
         preexec_fn=setpgrp,

--- a/docs/content/guide/installation.md
+++ b/docs/content/guide/installation.md
@@ -57,7 +57,6 @@ python setup.py develop</code></pre>
 While the following list might appear long, even very minimal systems should provide everything that's needed.
 
 * `apt-get` (only used with [pkg_apt](../items/pkg_apt.md) items)
-* `bash`
 * `cat`
 * `chmod`
 * `chown`


### PR DESCRIPTION
In the end, it probably does more harm than good, especially wrt BSD support.

related #241, #242 