### PR TITLE
Fixup for 96d3082a957bef51d31a58a2edbb9aac3dee958f

### DIFF
--- a/bundlewrap/cmdline/verify.py
+++ b/bundlewrap/cmdline/verify.py
@@ -106,8 +106,7 @@ def bw_verify(repo, args):
     worker_pool.run()
 
     if args['summary']:
-        for line in stats_summary(node_stats):
-            io.stdout(line)
+        stats_summary(node_stats)
 
     error_summary(errors)
 


### PR DESCRIPTION
stats_summary() prints output on its own and returns nothing. This is
the error I got:

    $ bw verify lulu
    node health:  100.0%  (302/302 OK)
    Traceback (most recent call last):
      File "/home/lulu/git/bundlewrap/bundlewrap/cmdline/__init__.py", line 66, in wrapper
        return f(*args, **kwargs)
      File "/home/lulu/git/bundlewrap/bundlewrap/cmdline/__init__.py", line 149, in main
        pargs.func(repo, text_pargs)
      File "/home/lulu/git/bundlewrap/bundlewrap/cmdline/verify.py", line 109, in bw_verify
        for line in stats_summary(node_stats):
    TypeError: 'NoneType' object is not iterable