### PR TITLE
keys.remove() now expects ValueError's instead of IndexErrors.

### DIFF
--- a/bundlewrap/items/directories.py
+++ b/bundlewrap/items/directories.py
@@ -78,7 +78,7 @@ class Directory(Item):
     def display_keys(self, cdict, sdict, keys):
         try:
             keys.remove('paths_to_purge')
-        except IndexError:
+        except ValueError:
             pass
         else:
             keys.append(UNMANAGED_PATH_DESC)


### PR DESCRIPTION
  File "/home/mreinhardt/py34venv/lib/python3.4/site-packages/bundlewrap/concurrency.py", line 143, in run
    result = self._get_result()
  File "/home/mreinhardt/py34venv/lib/python3.4/site-packages/bundlewrap/concurrency.py", line 83, in _get_result
    raise exception
  File "/usr/lib64/python3.4/concurrent/futures/thread.py", line 54, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/mreinhardt/py34venv/lib/python3.4/site-packages/bundlewrap/node.py", line 505, in apply
    profiling=profiling,
  File "/home/mreinhardt/py34venv/lib/python3.4/site-packages/bundlewrap/node.py", line 208, in apply_items
    worker_pool.run()
  File "/home/mreinhardt/py34venv/lib/python3.4/site-packages/bundlewrap/concurrency.py", line 152, in run
    raise exc
  File "/home/mreinhardt/py34venv/lib/python3.4/site-packages/bundlewrap/concurrency.py", line 143, in run
    result = self._get_result()
  File "/home/mreinhardt/py34venv/lib/python3.4/site-packages/bundlewrap/concurrency.py", line 83, in _get_result
    raise exception
  File "/usr/lib64/python3.4/concurrent/futures/thread.py", line 54, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/mreinhardt/py34venv/lib/python3.4/site-packages/bundlewrap/items/__init__.py", line 403, in apply
    status_before.keys_to_fix[:],
  File "<string>", line 80, in display_keys

ValueError('list.remove(x): x not in list',)
fra-1.s2s.rka: list.remove(x): x not in list