### PR TITLE
cache installed packages for pkg_dnf and pkg_yum

### DIFF
--- a/bundlewrap/items/pkg_dnf.py
+++ b/bundlewrap/items/pkg_dnf.py
@@ -3,64 +3,36 @@ from __future__ import unicode_literals
 
 from pipes import quote
 
-from bundlewrap.exceptions import BundleError
-from bundlewrap.items import Item
-from bundlewrap.utils.text import mark_for_translation as _
+from bundlewrap.items.pkg import Pkg
 
 
-def pkg_install(node, pkgname):
-    return node.run("dnf -d0 -e0 -y install {}".format(quote(pkgname)))
-
-
-def pkg_installed(node, pkgname):
-    result = node.run(
-        "dnf -d0 -e0 list installed {}".format(quote(pkgname)),
-        may_fail=True,
-    )
-    if result.return_code != 0:
-        return False
-    else:
-        return True
-
-
-def pkg_remove(node, pkgname):
-    return node.run("dnf -d0 -e0 -y remove {}".format(quote(pkgname)))
-
-
-class DnfPkg(Item):
+class DnfPkg(Pkg):
     """
     A package installed by dnf.
     """
     BLOCK_CONCURRENT = ["pkg_dnf", "pkg_yum"]
     BUNDLE_ATTRIBUTE_NAME = "pkg_dnf"
-    ITEM_ATTRIBUTES = {
-        'installed': True,
-    }
     ITEM_TYPE_NAME = "pkg_dnf"
 
-    def __repr__(self):
-        return "<DnfPkg name:{} installed:{}>".format(
-            self.name,
-            self.attributes['installed'],
+    def pkg_all_installed(self):
+        result = self.node.run("dnf -d0 -e0 list installed")
+        for line in result.stdout.decode('utf-8').strip().split("\n"):
+            yield line[0:].split()[0].split(".")[0]
+
+    def pkg_install(self):
+        return self.node.run(
+            "dnf -d0 -e0 -y "
+            "install {}".format(quote(self.name))
         )
 
-    def fix(self, status):
-        if self.attributes['installed'] is False:
-            pkg_remove(self.node, self.name)
-        else:
-            pkg_install(self.node, self.name)
+    def pkg_installed(self):
+        result = self.node.run(
+            "dnf -d0 -e0 list installed {}".format(quote(self.name)),
+            may_fail=True,
+        )
+        return result.return_code == 0
 
-    def sdict(self):
-        return {
-            'installed': pkg_installed(self.node, self.name),
-        }
-
-    @classmethod
-    def validate_attributes(cls, bundle, item_id, attributes):
-        if not isinstance(attributes.get('installed', True), bool):
-            raise BundleError(_(
-                "expected boolean for 'installed' on {item} in bundle '{bundle}'"
-            ).format(
-                bundle=bundle.name,
-                item=item_id,
-            ))
+    def pkg_remove(self):
+        return self.node.run(
+            "dnf -d0 -e0 -y remove {}".format(quote(self.name))
+        )

--- a/bundlewrap/items/pkg_yum.py
+++ b/bundlewrap/items/pkg_yum.py
@@ -10,7 +10,7 @@ class YumPkg(Pkg):
     """
     A package installed by yum.
     """
-   BLOCK_CONCURRENT = ["pkg_yum", "pkg_dnf"]
+    BLOCK_CONCURRENT = ["pkg_yum", "pkg_dnf"]
     BUNDLE_ATTRIBUTE_NAME = "pkg_yum"
     ITEM_TYPE_NAME = "pkg_yum"
 

--- a/bundlewrap/items/pkg_yum.py
+++ b/bundlewrap/items/pkg_yum.py
@@ -3,64 +3,36 @@ from __future__ import unicode_literals
 
 from pipes import quote
 
-from bundlewrap.exceptions import BundleError
-from bundlewrap.items import Item
-from bundlewrap.utils.text import mark_for_translation as _
+from bundlewrap.items.pkg import Pkg
 
 
-def pkg_install(node, pkgname):
-    return node.run("yum -d0 -e0 -y install {}".format(quote(pkgname)))
-
-
-def pkg_installed(node, pkgname):
-    result = node.run(
-        "yum -d0 -e0 list installed {}".format(quote(pkgname)),
-        may_fail=True,
-    )
-    if result.return_code != 0:
-        return False
-    else:
-        return True
-
-
-def pkg_remove(node, pkgname):
-    return node.run("yum -d0 -e0 -y remove {}".format(quote(pkgname)))
-
-
-class YumPkg(Item):
+class YumPkg(Pkg):
     """
     A package installed by yum.
     """
-    BLOCK_CONCURRENT = ["pkg_yum", "pkg_dnf"]
+   BLOCK_CONCURRENT = ["pkg_yum", "pkg_dnf"]
     BUNDLE_ATTRIBUTE_NAME = "pkg_yum"
-    ITEM_ATTRIBUTES = {
-        'installed': True,
-    }
     ITEM_TYPE_NAME = "pkg_yum"
 
-    def __repr__(self):
-        return "<YumPkg name:{} installed:{}>".format(
-            self.name,
-            self.attributes['installed'],
+    def pkg_all_installed(self):
+        result = self.node.run("yum -d0 -e0 list installed")
+        for line in result.stdout.decode('utf-8').strip().split("\n"):
+            yield line[0:].split()[0].split(".")[0]
+
+    def pkg_install(self):
+        return self.node.run(
+            "yum -d0 -e0 -y "
+            "install {}".format(quote(self.name))
         )
 
-    def fix(self, status):
-        if self.attributes['installed'] is False:
-            pkg_remove(self.node, self.name)
-        else:
-            pkg_install(self.node, self.name)
+    def pkg_installed(self):
+        result = self.node.run(
+            "yum -d0 -e0 list installed {}".format(quote(self.name)),
+            may_fail=True,
+        )
+        return result.return_code == 0
 
-    def sdict(self):
-        return {
-            'installed': pkg_installed(self.node, self.name),
-        }
-
-    @classmethod
-    def validate_attributes(cls, bundle, item_id, attributes):
-        if not isinstance(attributes.get('installed', True), bool):
-            raise BundleError(_(
-                "expected boolean for 'installed' on {item} in bundle '{bundle}'"
-            ).format(
-                bundle=bundle.name,
-                item=item_id,
-            ))
+    def pkg_remove(self):
+        return self.node.run(
+            "yum -d0 -e0 -y remove {}".format(quote(self.name))
+        )


### PR DESCRIPTION
As described in #295 one query to the package management system should be enough to verify if packages are installed.

This PR makes use of https://github.com/bundlewrap/bundlewrap/commit/86f552b4017584b1629f4522d901c0f08fccaa05 and https://github.com/bundlewrap/bundlewrap/commit/0ad7c7303546ff4682e886b23794a412a4bd3e96 to implement this feature for dnf and yum.

Comparison:

```
before:
i ╭─────────────────┬───────┬──────┬─────┬────────┬────────╮
i │ node            │ items │ good │ bad │ health │ time   │
i ├─────────────────┼───────┼──────┼─────┼────────┼────────┤
i │ sectumsempra    │   387 │  387 │   0 │ 100.0% │ 2m 28s │
i ╰─────────────────┴───────┴──────┴─────┴────────┴────────╯

after:
i ╭─────────────────┬───────┬──────┬─────┬────────┬──────╮
i │ node            │ items │ good │ bad │ health │ time │
i ├─────────────────┼───────┼──────┼─────┼────────┼──────┤
i │ sectumsempra    │   387 │  387 │   0 │ 100.0% │  15s │
i ╰─────────────────┴───────┴──────┴─────┴────────┴──────╯
```