### PR TITLE
add `—state`, item and attribute args to `bw items`

### DIFF
--- a/bundlewrap/cmdline/items.py
+++ b/bundlewrap/cmdline/items.py
@@ -6,7 +6,8 @@ from os.path import dirname, exists, join
 from sys import exit
 
 from ..utils.cmdline import get_node
-from ..utils.text import force_text, mark_for_translation as _
+from ..utils.statedict import statedict_to_json
+from ..utils.text import force_text, mark_for_translation as _, red
 from ..utils.ui import io
 
 
@@ -65,6 +66,16 @@ def bw_items(repo, args):
                 item.name.lstrip("/"),
             )))
             write_preview(item, args['file_preview_path'])
+    elif args['item']:
+        item = node.get_item(args['item'])
+        if args['show_sdict']:
+            statedict = item.sdict()
+        else:
+            statedict = item.cdict()
+        if args['attr']:
+            io.stdout(repr(statedict[args['attr']]))
+        else:
+            io.stdout(statedict_to_json(statedict, pretty=True))
     else:
         for item in sorted(node.items):
             if args['show_repr']:

--- a/bundlewrap/cmdline/items.py
+++ b/bundlewrap/cmdline/items.py
@@ -5,7 +5,7 @@ from os import makedirs
 from os.path import dirname, exists, join
 from sys import exit
 
-from ..utils.cmdline import get_node
+from ..utils.cmdline import get_item, get_node
 from ..utils.statedict import statedict_to_json
 from ..utils.text import force_text, mark_for_translation as _, red
 from ..utils.ui import io
@@ -26,7 +26,7 @@ def write_preview(file_item, base_path):
 def bw_items(repo, args):
     node = get_node(repo, args['node'], adhoc_nodes=args['adhoc_nodes'])
     if args['file_preview']:
-        item = node.get_item("file:{}".format(args['file_preview']))
+        item = get_item(node, "file:{}".format(args['file_preview']))
         if (
             item.attributes['content_type'] in ('any', 'base64', 'binary') or
             item.attributes['delete'] is True
@@ -67,7 +67,7 @@ def bw_items(repo, args):
             )))
             write_preview(item, args['file_preview_path'])
     elif args['item']:
-        item = node.get_item(args['item'])
+        item = get_item(node, args['item'])
         if args['show_sdict']:
             statedict = item.sdict()
         else:

--- a/bundlewrap/cmdline/items.py
+++ b/bundlewrap/cmdline/items.py
@@ -72,10 +72,13 @@ def bw_items(repo, args):
             statedict = item.sdict()
         else:
             statedict = item.cdict()
-        if args['attr']:
-            io.stdout(repr(statedict[args['attr']]))
+        if statedict is None:
+            io.stdout("REMOVE")
         else:
-            io.stdout(statedict_to_json(statedict, pretty=True))
+            if args['attr']:
+                io.stdout(repr(statedict[args['attr']]))
+            else:
+                io.stdout(statedict_to_json(statedict, pretty=True))
     else:
         for item in sorted(node.items):
             if args['show_repr']:

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -243,13 +243,27 @@ def build_parser_bw():
         help=_("list items for this node"),
     )
     parser_items.add_argument(
+        'item',
+        metavar=_("ITEM"),
+        nargs='?',
+        type=str,
+        help=_("show configuration for this item"),
+    )
+    parser_items.add_argument(
+        'attr',
+        metavar=_("ATTRIBUTE"),
+        nargs='?',
+        type=str,
+        help=_("show only this item attribute"),
+    )
+    parser_items.add_argument(
         "-f",
         "--file-preview",
         dest='file_preview',
         help=_("print preview of given file"),
         metavar=_("FILE"),
         required=False,
-        type=str,
+        type=str,  # TODO 3.0 convert to bool and use ITEM arg
     )
     parser_items.add_argument(
         "-w",
@@ -266,6 +280,12 @@ def build_parser_bw():
         action='store_true',
         dest='show_repr',
         help=_("show more verbose representation of each item"),
+    )
+    parser_items.add_argument(
+        "--state",
+        action='store_true',
+        dest='show_sdict',
+        help=_("show actual item status on node instead of should-be configuration"),
     )
 
     # bw lock

--- a/bundlewrap/utils/cmdline.py
+++ b/bundlewrap/utils/cmdline.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from sys import exit
 
-from ..exceptions import NoSuchNode, NoSuchGroup
+from ..exceptions import NoSuchGroup, NoSuchItem, NoSuchNode
 from . import names
 from .text import mark_for_translation as _, red
 from .ui import io
@@ -22,7 +22,7 @@ def get_group(repo, group_name):
 def get_item(node, item_id):
     try:
         return node.get_item(item_id)
-    except NoSuchGroup:
+    except NoSuchItem:
         io.stderr(_("{x} No such item on node '{node}': {item}").format(
             item=item_id,
             node=node.name,


### PR DESCRIPTION
This allows for exploration of item cdicts and sdicts from the CLI. That has previously only been possible for cdicts through `bw hash -d`.