### PR TITLE
Use rm's exit code to determine return value of softlock_remove()

### DIFF
--- a/bundlewrap/lock.py
+++ b/bundlewrap/lock.py
@@ -191,12 +191,9 @@ def softlock_list(node):
 
 
 def softlock_remove(node, lock_id):
-    for lock in softlock_list(node):
-        if lock['id'] == lock_id:
-            io.debug(_("removing soft lock {id} from node {node}").format(
-                id=lock_id,
-                node=node.name,
-            ))
-            node.run("rm {}".format(SOFT_LOCK_FILE.format(id=lock_id)))
-            return True
-    return False
+    io.debug(_("removing soft lock {id} from node {node}").format(
+        id=lock_id,
+        node=node.name,
+    ))
+    rm = node.run("rm {}".format(SOFT_LOCK_FILE.format(id=lock_id)), may_fail=True)
+    return rm.return_code == 0


### PR DESCRIPTION
Fix for #317.