### PR TITLE
node.py: move oralelinux to OS_FAMILY_REDHAT

### DIFF
--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -333,6 +333,7 @@ class Node(object):
         'rhel',
         'centos',
         'fedora',
+        'oraclelinux',
     )
 
     OS_FAMILY_LINUX = (
@@ -341,7 +342,6 @@ class Node(object):
         'opensuse',
         'gentoo',
         'linux',
-        'oraclelinux',
     ) + \
         OS_FAMILY_DEBIAN + \
         OS_FAMILY_REDHAT


### PR DESCRIPTION
Oracle Linux is actually based on RHEL. The changes are minimal and full compatibility should be given when it comes to bw.