### PR TITLE
postgres_db: Allow customization of encoding and collation

### DIFF
--- a/bundlewrap/items/postgres_dbs.py
+++ b/bundlewrap/items/postgres_dbs.py
@@ -8,11 +8,28 @@ from bundlewrap.items import Item
 from bundlewrap.utils.text import force_text, mark_for_translation as _
 
 
-def create_db(node, name, owner):
-    return node.run("sudo -u postgres createdb -wO {owner} {name}".format(
-        name=name,
-        owner=owner,
-    ))
+def create_db(node, name, attributes):
+    template = None
+    cmd = "sudo -u postgres createdb -wO {} ".format(attributes['owner'])
+
+    if attributes.get('collation') is not None:
+        cmd += "--lc-collate={} ".format(attributes['collation'])
+        template = "template0"
+
+    if attributes.get('ctype') is not None:
+        cmd += "--lc-ctype={} ".format(attributes['ctype'])
+        template = "template0"
+
+    if attributes.get('encoding') is not None:
+        cmd += "--encoding={} ".format(attributes['encoding'])
+        template = "template0"
+
+    if template is not None:
+        cmd += "--template={} ".format(template)
+
+    cmd += name
+
+    return node.run(cmd)
 
 
 def drop_db(node, name):
@@ -47,6 +64,9 @@ class PostgresDB(Item):
     BUNDLE_ATTRIBUTE_NAME = "postgres_dbs"
     ITEM_ATTRIBUTES = {
         'delete': False,
+        'collation': None,  # creation-time only
+        'ctype': None,      # creation-time only
+        'encoding': None,   # creation-time only
         'owner': "postgres",
     }
     ITEM_TYPE_NAME = "postgres_db"
@@ -64,7 +84,7 @@ class PostgresDB(Item):
         if status.must_be_deleted:
             drop_db(self.node, self.name)
         elif status.must_be_created:
-            create_db(self.node, self.name, self.attributes['owner'])
+            create_db(self.node, self.name, self.attributes)
         elif 'owner' in status.keys_to_fix:
             set_owner(self.node, self.name, self.attributes['owner'])
         else:

--- a/bundlewrap/items/postgres_dbs.py
+++ b/bundlewrap/items/postgres_dbs.py
@@ -8,20 +8,20 @@ from bundlewrap.items import Item
 from bundlewrap.utils.text import force_text, mark_for_translation as _
 
 
-def create_db(node, name, attributes):
+def create_db(node, name, owner, when_creating):
     template = None
-    cmd = "sudo -u postgres createdb -wO {} ".format(attributes['owner'])
+    cmd = "sudo -u postgres createdb -wO {} ".format(owner)
 
-    if attributes.get('collation') is not None:
-        cmd += "--lc-collate={} ".format(attributes['collation'])
+    if when_creating.get('collation') is not None:
+        cmd += "--lc-collate={} ".format(when_creating['collation'])
         template = "template0"
 
-    if attributes.get('ctype') is not None:
-        cmd += "--lc-ctype={} ".format(attributes['ctype'])
+    if when_creating.get('ctype') is not None:
+        cmd += "--lc-ctype={} ".format(when_creating['ctype'])
         template = "template0"
 
-    if attributes.get('encoding') is not None:
-        cmd += "--encoding={} ".format(attributes['encoding'])
+    if when_creating.get('encoding') is not None:
+        cmd += "--encoding={} ".format(when_creating['encoding'])
         template = "template0"
 
     if template is not None:
@@ -64,12 +64,14 @@ class PostgresDB(Item):
     BUNDLE_ATTRIBUTE_NAME = "postgres_dbs"
     ITEM_ATTRIBUTES = {
         'delete': False,
-        'collation': None,  # creation-time only
-        'ctype': None,      # creation-time only
-        'encoding': None,   # creation-time only
         'owner': "postgres",
     }
     ITEM_TYPE_NAME = "postgres_db"
+    WHEN_CREATING_ATTRIBUTES = {
+        'collation': None,
+        'ctype': None,
+        'encoding': None,
+    }
 
     def __repr__(self):
         return "<PostgresDB name:{}>".format(self.name)
@@ -84,7 +86,7 @@ class PostgresDB(Item):
         if status.must_be_deleted:
             drop_db(self.node, self.name)
         elif status.must_be_created:
-            create_db(self.node, self.name, self.attributes)
+            create_db(self.node, self.name, self.attributes['owner'], self.when_creating)
         elif 'owner' in status.keys_to_fix:
             set_owner(self.node, self.name, self.attributes['owner'])
         else:

--- a/docs/content/items/postgres_db.md
+++ b/docs/content/items/postgres_db.md
@@ -4,6 +4,9 @@ Manages Postgres databases.
 
     postgres_dbs = {
         "mydatabase": {
+            "encoding": "LATIN1",
+            "collation": "de_DE.ISO-8859-1",
+            "ctype": "de_DE.ISO-8859-1",
             "owner": "me",
         },
     }
@@ -19,3 +22,9 @@ See also: [The list of generic builtin item attributes](../repo/bundles.md#built
 ### owner
 
 Name of the role which owns this database (defaults to `"postgres"`).
+
+### encoding, collation, and ctype
+
+By default, BundleWrap will only create a database using your default PostgreSQL template, which is most likely `template1`. This means it will use the same encoding and database that `template1` uses. By specifying any of the attributes `encoding`, `collation`, or `ctype`, BundleWrap will instead create a new database from `template0`, thus allowing you to override said database attributes.
+
+These options are creation-time only.

--- a/docs/content/items/postgres_db.md
+++ b/docs/content/items/postgres_db.md
@@ -27,6 +27,6 @@ Name of the role which owns this database (defaults to `"postgres"`).
 
 ### encoding, collation, and ctype
 
-By default, BundleWrap will only create a database using your default PostgreSQL template, which is most likely `template1`. This means it will use the same encoding and database that `template1` uses. By specifying any of the attributes `encoding`, `collation`, or `ctype`, BundleWrap will instead create a new database from `template0`, thus allowing you to override said database attributes.
+By default, BundleWrap will only create a database using your default PostgreSQL template, which most likely is `template1`. This means it will use the same encoding and collation that `template1` uses. By specifying any of the attributes `encoding`, `collation`, or `ctype`, BundleWrap will instead create a new database from `template0`, thus allowing you to override said database attributes.
 
 These options are creation-time only.

--- a/docs/content/items/postgres_db.md
+++ b/docs/content/items/postgres_db.md
@@ -4,10 +4,12 @@ Manages Postgres databases.
 
     postgres_dbs = {
         "mydatabase": {
-            "encoding": "LATIN1",
-            "collation": "de_DE.ISO-8859-1",
-            "ctype": "de_DE.ISO-8859-1",
             "owner": "me",
+            "when_creating": {
+                "encoding": "LATIN1",
+                "collation": "de_DE.ISO-8859-1",
+                "ctype": "de_DE.ISO-8859-1",
+            },
         },
     }
 


### PR DESCRIPTION
It's not possible to change these attributes after the DB has been created, so they're all creation-time only. :/