### PR TITLE
make copy of values if we want to change them for diff

### DIFF
--- a/bundlewrap/utils/statedict.py
+++ b/bundlewrap/utils/statedict.py
@@ -57,6 +57,10 @@ def diff_value_int(title, value1, value2):
 
 
 def diff_value_list(title, value1, value2):
+    # make copy since we change the values
+    value1 = value1.copy()
+    value2 = value2.copy()
+
     if isinstance(value1, set):
         value1 = sorted(value1)
         value2 = sorted(value2)


### PR DESCRIPTION
There is a problem with the validation of dict values in items. BW will add an empty item to the end. I narrowed it down to diff_value_list. If you make a copy there before you add items to the list, all is working correct.

This problem only occures, in the interactive mode, since the sdict function is called twice, and the second time the sdict alreay has the empty element, and therefor the validation fails, which states fix failed, but it happened and worked.