### PR TITLE
add the ‘comment’ attribute to all items

### DIFF
--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -6,6 +6,7 @@ Repository.item_classes loads them as files.
 from __future__ import unicode_literals
 from copy import copy
 from datetime import datetime
+from inspect import cleandoc
 from os.path import join
 from textwrap import TextWrapper
 
@@ -42,7 +43,7 @@ wrapper = TextWrapper(
 
 def format_comment(comment):
     result = "\n\n"
-    for line in wrapper.wrap(comment.strip()):
+    for line in wrapper.wrap(cleandoc(comment)):
         for inlineline in line.split("\n"):
             result += "# {}\n".format(italic(inlineline))
     return result

--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -7,16 +7,18 @@ from __future__ import unicode_literals
 from copy import copy
 from datetime import datetime
 from os.path import join
+from textwrap import TextWrapper
 
 from bundlewrap.exceptions import BundleError, ItemDependencyError, FaultUnavailable
 from bundlewrap.utils import cached_property
 from bundlewrap.utils.statedict import diff_keys, diff_value, hash_statedict, validate_statedict
 from bundlewrap.utils.text import force_text, mark_for_translation as _
-from bundlewrap.utils.text import blue, bold, wrap_question
+from bundlewrap.utils.text import blue, bold, italic, wrap_question
 from bundlewrap.utils.ui import io
 
 BUILTIN_ITEM_ATTRIBUTES = {
     'cascade_skip': None,
+    'comment': None,
     'needed_by': [],
     'needs': [],
     'preceded_by': [],
@@ -29,6 +31,8 @@ BUILTIN_ITEM_ATTRIBUTES = {
     'unless': "",
     'when_creating': {},
 }
+
+wrapper = TextWrapper(break_long_words=False, break_on_hyphens=False)
 
 
 class ItemStatus(object):
@@ -455,6 +459,10 @@ class Item(object):
                         keys_to_fix,
                     )
                     question_text = self.ask(cdict, sdict, keys_to_fix)
+                if self.comment:
+                    question_text += "\n\n"
+                    for line in wrapper.wrap(self.comment):
+                        question_text += italic(line) + "\n"
                 question = wrap_question(
                     self.id,
                     question_text,

--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -32,7 +32,20 @@ BUILTIN_ITEM_ATTRIBUTES = {
     'when_creating': {},
 }
 
-wrapper = TextWrapper(break_long_words=False, break_on_hyphens=False)
+wrapper = TextWrapper(
+    break_long_words=False,
+    break_on_hyphens=False,
+    expand_tabs=False,
+    replace_whitespace=False,
+)
+
+
+def format_comment(comment):
+    result = "\n\n"
+    for line in wrapper.wrap(comment.strip()):
+        for inlineline in line.split("\n"):
+            result += "# {}\n".format(italic(inlineline))
+    return result
 
 
 class ItemStatus(object):
@@ -460,9 +473,7 @@ class Item(object):
                     )
                     question_text = self.ask(cdict, sdict, keys_to_fix)
                 if self.comment:
-                    question_text += "\n\n"
-                    for line in wrapper.wrap(self.comment):
-                        question_text += "# {}\n".format(italic(line))
+                    question_text += format_comment(self.comment)
                 question = wrap_question(
                     self.id,
                     question_text,

--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -462,7 +462,7 @@ class Item(object):
                 if self.comment:
                     question_text += "\n\n"
                     for line in wrapper.wrap(self.comment):
-                        question_text += italic(line) + "\n"
+                        question_text += "# {}\n".format(italic(line))
                 question = wrap_question(
                     self.id,
                     question_text,

--- a/bundlewrap/utils/text.py
+++ b/bundlewrap/utils/text.py
@@ -47,6 +47,11 @@ def inverse(text):
 
 
 @ansi_wrapper
+def italic(text):
+    return "\033[3m{}\033[0m".format(text)
+
+
+@ansi_wrapper
 def green(text):
     return "\033[32m{}\033[0m".format(text)
 

--- a/docs/content/repo/bundles.md
+++ b/docs/content/repo/bundles.md
@@ -70,6 +70,12 @@ There are also attributes that can be applied to any kind of item.
 
 <br>
 
+### comment
+
+This is a string that will be displayed in interactive mode (`bw apply -i`) whenever the item is to be changed in any way. You can use it to warn users before they start disruptive actions.
+
+<br>
+
 ### error_on_missing_fault
 
 This will simply skip an item instead of raising an error when a Fault used for an attribute on the item is unavailable. Faults are special objects used by `repo.vault` to [handle secrets](../guide/secrets.md). A Fault being unavailable can mean you're missing the secret key required to decrypt a secret you're trying to use as an item attribute value.


### PR DESCRIPTION
PR for #340 

still wondering if we should call it "interactive_comment" or something since "comment" is pretty generic and might be used as an item-specific attribute