### PR TITLE
Actions: Pipes

### DIFF
--- a/bundlewrap/items/actions.py
+++ b/bundlewrap/items/actions.py
@@ -69,9 +69,10 @@ class Action(Item):
                 ))
                 return (self.STATUS_SKIPPED, ["unless"])
 
-        question_body = self.attributes['command']
+        question_body = ""
         if self.attributes['data_stdin'] is not None:
-            question_body += "\n\n<data being fed to stdin>"
+            question_body += "<" + _("data") + "> | "
+        question_body += self.attributes['command']
         if self.comment:
             question_body += format_comment(self.comment)
 

--- a/bundlewrap/items/actions.py
+++ b/bundlewrap/items/actions.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from bundlewrap.exceptions import ActionFailure, BundleError
 from bundlewrap.items import format_comment, Item
+from bundlewrap.utils import Fault
 from bundlewrap.utils.ui import io
 from bundlewrap.utils.text import mark_for_translation as _
 from bundlewrap.utils.text import blue, bold, wrap_question
@@ -135,8 +136,10 @@ class Action(Item):
         if self.attributes['data_stdin'] is not None:
             data_stdin = self.attributes['data_stdin']
             # Allow users to use either a string/unicode object or raw
-            # bytes.
-            if type(data_stdin) is not bytes:
+            # bytes -- or Faults.
+            if isinstance(data_stdin, Fault):
+                data_stdin = data_stdin.value
+            elif type(data_stdin) is not bytes:
                 data_stdin = data_stdin.encode('UTF-8')
         else:
             data_stdin = None

--- a/bundlewrap/items/actions.py
+++ b/bundlewrap/items/actions.py
@@ -139,7 +139,7 @@ class Action(Item):
             # bytes -- or Faults.
             if isinstance(data_stdin, Fault):
                 data_stdin = data_stdin.value
-            elif type(data_stdin) is not bytes:
+            if type(data_stdin) is not bytes:
                 data_stdin = data_stdin.encode('UTF-8')
         else:
             data_stdin = None

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -660,7 +660,7 @@ class Node(object):
         """
         return self.repo._metadata_for_node(self.name, partial=True)
 
-    def run(self, command, may_fail=False, log_output=False):
+    def run(self, command, data_stdin=None, may_fail=False, log_output=False):
         if log_output:
             def log_function(msg):
                 io.stdout("{x} {node}  {msg}".format(
@@ -696,6 +696,7 @@ class Node(object):
             self.hostname,
             command,
             add_host_keys=add_host_keys,
+            data_stdin=data_stdin,
             ignore_failure=may_fail,
             log_function=log_function,
             wrapper_inner=self.cmd_wrapper_inner,

--- a/bundlewrap/operations.py
+++ b/bundlewrap/operations.py
@@ -90,6 +90,7 @@ def run(
     hostname,
     command,
     add_host_keys=False,
+    data_stdin=None,
     ignore_failure=False,
     log_function=None,
     wrapper_inner="{}",
@@ -137,6 +138,9 @@ def run(
         stdout=stdout_fd_w,
     )
     io._ssh_pids.append(ssh_process.pid)
+
+    if data_stdin is not None:
+        ssh_process.stdin.write(data_stdin)
 
     quit_event = Event()
     stdout_thread = Thread(

--- a/docs/content/items/action.md
+++ b/docs/content/items/action.md
@@ -24,6 +24,12 @@ The only required attribute. This is the command that will be run on the node wi
 
 <br>
 
+### data_stdin
+
+You can pipe data directly to the command running on the node. To do so, use this attribute. If it's a string or unicode object, it will always be encoded as UTF-8. Alternatively, you can use raw bytes.
+
+<br>
+
 ### expected_return_code
 
 Defaults to `0`. If the return code of your command is anything else, the action is considered failed. You can also set this to `None` and any return code will be accepted.

--- a/tests/integration/bw_apply_actions.py
+++ b/tests/integration/bw_apply_actions.py
@@ -48,7 +48,31 @@ def test_action_fail(tmpdir):
     run("bw apply localhost", path=str(tmpdir))
 
 
-def test_action_pipe(tmpdir):
+def test_action_pipe_binary(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'actions': {
+                    "pipe": {
+                        'command': "cat",
+                        'data_stdin': b"hello\000world",
+                        'expected_stdout': b"hello\000world",
+                    },
+                },
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+    run("bw apply localhost", path=str(tmpdir))
+
+
+def test_action_pipe_utf8(tmpdir):
     make_repo(
         tmpdir,
         bundles={

--- a/tests/integration/bw_apply_actions.py
+++ b/tests/integration/bw_apply_actions.py
@@ -46,3 +46,27 @@ def test_action_fail(tmpdir):
         },
     )
     run("bw apply localhost", path=str(tmpdir))
+
+
+def test_action_pipe(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'actions': {
+                    "pipe": {
+                        'command': "cat",
+                        'data_stdin': "hello\n",
+                        'expected_stdout': "hello\n",
+                    },
+                },
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+    run("bw apply localhost", path=str(tmpdir))

--- a/tests/integration/bw_apply_actions.py
+++ b/tests/integration/bw_apply_actions.py
@@ -56,8 +56,8 @@ def test_action_pipe(tmpdir):
                 'actions': {
                     "pipe": {
                         'command': "cat",
-                        'data_stdin': "hello\n",
-                        'expected_stdout': "hello\n",
+                        'data_stdin': "hello 🐧\n",
+                        'expected_stdout': "hello 🐧\n",
                     },
                 },
             },


### PR DESCRIPTION
```
actions = {
    'decrypt': {
        'command': 'cryptsetup --batch-mode luksOpen /dev/foo',
        'data_stdin': 'my_secret_key',
    },
}
```

Should the value of `data_stdin` be shown to the user? I don't think so. It could be large or binary. If we show it, we must also crop it if needed.