### PR TITLE
Node magic number

### DIFF
--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from datetime import datetime, timedelta
+from hashlib import md5
 from os import environ
 from sys import exit
 from threading import Lock
@@ -525,6 +526,10 @@ class Node(object):
             for bundle in self.bundles:
                 for item in bundle.items:
                     yield item
+
+    @cached_property
+    def magic_number(self):
+        return int(md5(self.name.encode('UTF-8')).hexdigest(), 16)
 
     @property
     def _static_items(self):

--- a/docs/content/repo/nodes.py.md
+++ b/docs/content/repo/nodes.py.md
@@ -71,6 +71,16 @@ A string used as a DNS name when connecting to this node. May also be an IP addr
 Cannot be set at group level.
 
 
+### magic_number
+
+A large number derived from the node's name. This number is very likely to be unique for your entire repository. You can, for example, use this number to easily "jitter" cronjobs:
+
+    '{} {} * * * root /my/script'.format(
+        node.magic_number % 60,
+        node.magic_number % 2 + 4,
+    )
+
+
 ### metadata
 
 This can be a dictionary of arbitrary data (some type restrictions apply). You can access it from your templates as `node.metadata`. Use this to attach custom data (such as a list of IP addresses that should be configured on the target node) to the node. Note that you can also define metadata at the [group level](groups.py.md#metadata), but node metadata has higher priority.


### PR DESCRIPTION
We currently have something like this as a metadata processor. It's rather annoying to use, though, since you *always* have to check if that particular metadata is ready -- if not, bail out and try again later.

By moving this to core bw, `node.magic_number` is always guaranteed to exist and can be used right away.

(You could also interpret this as a flaw in the design of metadata processors/usage. It's a very common pattern: Check if certain metadata exists and retry later if it doesn't. Quite some amounts of boiler plate code.)