### PR TITLE
pkg_openbsd: Fix handling of empty output from "pkg_info"

### DIFF
--- a/bundlewrap/items/pkg_openbsd.py
+++ b/bundlewrap/items/pkg_openbsd.py
@@ -22,7 +22,7 @@ def pkg_installed(node, pkgname):
         "pkg_info | cut -f 1 -d ' '",
         may_fail=True,
     )
-    for line in result.stdout.decode('utf-8').strip().split("\n"):
+    for line in result.stdout.decode('utf-8').strip().splitlines():
         installed_package, installed_version = PKGSPEC_REGEX.match(line).groups()
         if installed_package == pkgname:
             return installed_version


### PR DESCRIPTION
If no packages are installed on the system, then "pkg_info" prints
nothing, i.e. an empty string. That's handled badly by split("\n"):

    Python 3.6.2 (default, Jul 20 2017, 03:52:27)
    [GCC 7.1.1 20170630] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> "".split("\n")
    ['']

The following code does not expect to work on an empty string.

splitlines() handles the situation much better by returning an empty
list:

    Python 3.6.2 (default, Jul 20 2017, 03:52:27)
    [GCC 7.1.1 20170630] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> "".splitlines()
    []