### PR TITLE
[WIP] try getting multiline job info to work

### DIFF
--- a/bundlewrap/utils/ui.py
+++ b/bundlewrap/utils/ui.py
@@ -324,7 +324,7 @@ class IOManager(object):
 
     def _clear_last_job(self):
         if self.jobs and TTY:
-            write_to_stream(STDOUT_WRITER, "\r\033[K")
+            write_to_stream(STDOUT_WRITER, "\r\033[K\033[F\033[K")
 
     def _signal_handler_thread_body(self):
         while self._active:
@@ -366,6 +366,7 @@ class IOManager(object):
 
     def _write_current_job(self):
         if self.jobs and TTY:
-            write_to_stream(STDOUT_WRITER, inverse("{} ".format(self.jobs[-1])[:term_width() - 1]))
+            write_to_stream(STDOUT_WRITER, inverse("{} \n".format(self.jobs[-1])[:term_width() - 1]))
+            write_to_stream(STDOUT_WRITER, "{} ".format(self.jobs[-1])[:term_width() - 1])
 
 io = IOManager()


### PR DESCRIPTION
I've not yet given up on getting a multiline progress bar to work.

With the changes in this PR, this works as expected (printing an inverted and regular version of the same status line for now):

```python
from time import sleep
from bundlewrap.utils.ui import io


io.activate()
io.stdout("hi")
with io.job("imajob"):
    for i in range(10):
        io.stdout(str(i))
        sleep(0.5)
io.stdout("bye")
io.deactivate()
```

"Real" bw stilll messes up my terminal though.