### PR TITLE
fix prepare_dependencies in bw plot

### DIFF
--- a/bundlewrap/cmdline/plot.py
+++ b/bundlewrap/cmdline/plot.py
@@ -29,7 +29,7 @@ def bw_plot_node(repo, args):
     node = get_node(repo, args['node'], adhoc_nodes=args['adhoc_nodes'])
     for line in graph_for_items(
         node.name,
-        prepare_dependencies(node.items, node.os, node.os_version),
+        prepare_dependencies(node.items, node.name, node.os, node.os_version),
         cluster=args['cluster'],
         concurrency=args['depends_concurrency'],
         static=args['depends_static'],


### PR DESCRIPTION
The error was:

```
  File "/Users/ayik/Repo/Python/Utils/bundlewrap/bundlewrap/cmdline/plot.py", line 32, in bw_plot_node
    prepare_dependencies(node.items, node.os, node.os_version),
  File "/Users/ayik/Repo/Python/Utils/bundlewrap/bundlewrap/utils/ui.py", line 359, in inner_wrapper
    return wrapped_function(*args, **kwargs)
TypeError: prepare_dependencies() missing 1 required positional argument: 'node_os_version'
```

According to Contributing Doc about CAA, i think this patch is trivial / small so that i don't need to sign CAA.