### PR TITLE
pkg_openbsd: Support flavors

### DIFF
--- a/bundlewrap/items/pkg_openbsd.py
+++ b/bundlewrap/items/pkg_openbsd.py
@@ -99,7 +99,7 @@ class OpenBSDPkg(Item):
         version, flavor = pkg_installed(self.node, self.name)
         return {
             'installed': bool(version),
-            'flavor': flavor if version else _("none"),
+            'flavor': flavor if flavor else _("none"),
             'version': version if version else _("none"),
         }
 

--- a/docs/content/items/pkg_openbsd.md
+++ b/docs/content/items/pkg_openbsd.md
@@ -13,6 +13,9 @@ Handles packages installed by `pkg_add` on OpenBSD systems.
         "baz": {
             "installed": False,
         },
+        "qux": {
+            "flavor": "no_x11",
+        },
     }
 
 <br><br>
@@ -29,6 +32,16 @@ See also: [The list of generic builtin item attributes](../repo/items.py.md#buil
 
 <hr>
 
+## flavor
+
+Optional, defaults to the "normal" flavor.
+
+Ignored when `version` is set or when `installed` is `False`.
+
+<hr>
+
 ## version
 
-Optional version string. Required for packages that offer multiple variants (like nginx or sudo). Ignored when `installed` is `False`.
+Optional version string. Can be used to select one specific version of a package, including its flavor. For example, set this to `1.0.4p0-socks` for the package `irssi` to run `pkg_add irssi-1.0.4p0-socks`.
+
+Ignored when `flavor` is set or when `installed` is `False`.

--- a/docs/content/items/pkg_openbsd.md
+++ b/docs/content/items/pkg_openbsd.md
@@ -36,12 +36,12 @@ See also: [The list of generic builtin item attributes](../repo/items.py.md#buil
 
 Optional, defaults to the "normal" flavor.
 
-Ignored when `version` is set or when `installed` is `False`.
+Can be used together with `version`. Ignored when `installed` is `False`.
 
 <hr>
 
 ## version
 
-Optional version string. Can be used to select one specific version of a package, including its flavor. For example, set this to `1.0.4p0-socks` for the package `irssi` to run `pkg_add irssi-1.0.4p0-socks`.
+Optional version string. Can be used to select one specific version of a package.
 
-Ignored when `flavor` is set or when `installed` is `False`.
+Can be used together with `flavor`. Ignored when `installed` is `False`.


### PR DESCRIPTION
Setting "version" to select a flavor is a bit flawed because you have
to, well, select a *version*. This is not what you actually want most of
the time (at least I don't). I want to be able to select a particular
flavor and, more importantly, it shall default to the "normal" flavor if
unset.

Some examples:

    pkg_add foo
        Installs most recent version of package "foo". If there are
        multiple flavors of that package, users will be asked
        interactively to select one of them.

    pkg_add foo--
        Installs most recent version of package "foo" and selects the
        "normal" flavor.

    pkg_add foo--bar
        Installs most recent version of package "foo" and selects the
        "bar" flavor.

    pkg_add foo-1.0.0-bar
        Explicitly installs version "1.0.0" of flavor "bar".

With this patch, bw will do a "pkg_add foo--" by default. If you set a
flavor, "pkg_add foo--bar" will be used. If you set a version, the
flavor attribute will be ignored completely and "pkg_add
foo-version-bar" will be used.

I had to adjust PKGSPEC_REGEX because it was too greedy.