### PR TITLE
fix details kwarg in handle_apply_result in node.py 

### DIFF
--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -169,7 +169,7 @@ def apply_items(
                     skipped_item,
                     Item.STATUS_SKIPPED,
                     interactive,
-                    details=[_("dep failed")],
+                    details=Item.SKIP_REASON_DEP_FAILED,
                 )
                 results.append((skipped_item.id, Item.STATUS_SKIPPED, timedelta(0)))
         elif status_code in (Item.STATUS_FIXED, Item.STATUS_ACTION_SUCCEEDED):


### PR DESCRIPTION
Hi, since i am using master on my dev machine, i hit a bug

```
  File "/Users/ayik/Repo/Python/Iaac/bundlewrap/bundlewrap/node.py", line 278, in format_item_result
    details_text = "({})".format(Item.SKIP_REASON_DESC[details])

TypeError("unhashable type: 'list'",)
vm1: unhashable type: 'list'
```

seeing other parts of the code, i think `details` kwargs should be an integer instead of a `list`. Feel free to dismiss this PR if this fix is wrong

thank you