### PR TITLE
pkg_openbsd: Only use "none" in sdict if not installed

### DIFF
--- a/bundlewrap/items/pkg_openbsd.py
+++ b/bundlewrap/items/pkg_openbsd.py
@@ -99,7 +99,7 @@ class OpenBSDPkg(Item):
         version, flavor = pkg_installed(self.node, self.name)
         return {
             'installed': bool(version),
-            'flavor': flavor if flavor else _("none"),
+            'flavor': flavor if flavor is not None else _("none"),
             'version': version if version else _("none"),
         }
 


### PR DESCRIPTION
If a package is NOT installed, its flavor is unknown.

If a package IS installed, the flavor can be the empty string
(indicating the "normal" flavor) or some non-empty string (indicating
exactly that flavor). The flavor of an installed package cannot be
"None".

In other words, we must use the value of the variable "flavor" as
returned by pkg_installed(), unless the variable "version" indicates
that the package is not installed at all -- in which case "flavor" will
be set to "None" which we must substitute by _("none").

This patch fixes a regression in bw 3.2.0: bw would always report
packages as "installed as the wrong flavor" if "pkg_info" didn't show a
flavor for a package.