### PR TITLE
postgres_*: No longer throw exceptions

### DIFF
--- a/bundlewrap/items/postgres_roles.py
+++ b/bundlewrap/items/postgres_roles.py
@@ -16,7 +16,7 @@ AUTHID_COLUMNS = {
 
 
 def delete_role(node, role):
-    node.run("sudo -u postgres dropuser -w {}".format(role))
+    node.run("sudo -u postgres dropuser -w {}".format(role), may_fail=True)
 
 
 def fix_role(node, role, attrs, create=False):
@@ -28,14 +28,18 @@ def fix_role(node, role, attrs, create=False):
             password="" if attrs['password_hash'] is None else password,
             role=role,
             superuser="" if attrs['superuser'] is True else "NO",
-        )
+        ),
+        may_fail=True,
     )
 
 
 def get_role(node, role):
     result = node.run("echo \"SELECT rolcanlogin, rolsuper, rolpassword from pg_authid "
                       "WHERE rolname='{}'\" "
-                      "| sudo -u postgres psql -Anqwx -F '|'".format(role))
+                      "| sudo -u postgres psql -Anqwx -F '|'".format(role),
+                      may_fail=True)
+    if result.return_code != 0:
+        return None
 
     role_attrs = {}
     for line in force_text(result.stdout).strip().split("\n"):


### PR DESCRIPTION
Assigning postgres_* items to a node and then running "bw verify $node"
results in some RemoteExceptions. That's because we try to run "sudo
postgres ...", but the user "postgres" does not yet exist. Usually,
bundles will have dependencies for that (install pkg_apt:postgresql
before creating any databases), but "bw verify" ignores dependencies.

So, allow these ".run()" calls to fail. This makes "bw verify" report
items as failed -- this is what we want.