### PR TITLE
made code in docu path independent

### DIFF
--- a/docs/content/repo/nodes.py.md
+++ b/docs/content/repo/nodes.py.md
@@ -38,9 +38,10 @@ You are not confined to the static way of defining a node list as shown above. Y
 Especially in larger installations, a single nodes.py can become inconvenient to work with. This example reads nodes from a `nodes/` directory.
 
 	from glob import glob
+	from os.path import join
 
 	nodes = {}
-	for node in glob("nodes/*.py"):
+	for node in glob(join(repo_path, "nodes", "*.py")):
 	    with open(node, 'r') as f:
 	        exec(f.read())
 


### PR DESCRIPTION
The code which is shown in the documentation for searching a nodes folder for nodes files is not path independent. If you try to use this code with an script it does not work as expected, since it does not find its nodes files.

This patch adds the repo path to the mix, which fixes the problem. Additionaly it adds the os.path.join method, which makes this code run on windows as well.