### PR TITLE
KubernetesItem: .decode() the output of kubectl

### DIFF
--- a/bundlewrap/items/kubernetes.py
+++ b/bundlewrap/items/kubernetes.py
@@ -168,7 +168,7 @@ class KubernetesItem(Item):
     def sdict(self):
         result = run_local(self._kubectl + ["get", "-o", "json", self.KIND, self.resource_name])
         if result.return_code == 0:
-            full_json_response = json.loads(result.stdout)
+            full_json_response = json.loads(result.stdout.decode('utf-8'))
             if full_json_response.get("status", {}).get("phase") == "Terminating":
                 # this resource is currently being deleted, consider it gone
                 return None


### PR DESCRIPTION
"Older" versions of Python (< 3.6?) appear to need this, while Python 3.7 is fine:

```
Python 3.7.0 (default, Jul 15 2018, 10:44:58) 
[GCC 8.1.1 20180531] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from json import loads
>>> loads(b'{}')
{}
>>> loads('{}')
{}
```