### PR TITLE
Fault: Support .b64encode()

### DIFF
--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from base64 import b64encode
 from codecs import getwriter
 from contextlib import contextmanager
 import hashlib
@@ -106,6 +107,11 @@ class Fault(object):
 
     def __str__(self):
         return str(self.value)
+
+    def b64encode(self):
+        def callback():
+            return b64encode(self.value.encode('UTF-8')).decode('UTF-8')
+        return Fault(callback)
 
     def format_into(self, format_string):
         def callback():

--- a/docs/content/guide/api.md
+++ b/docs/content/guide/api.md
@@ -248,5 +248,7 @@ Faults also support some rudimentary string operations such as appending a strin
 	'VOd5PC:JUgYUb'
 	>>> repo.vault.password_for("1").format_into("Password: {}").value
 	'Password: VOd5PC'
+	>>> repo.vault.password_for("1").b64encode().value
+	'Vk9kNVA='
 
 These string methods are supported on Faults: `format`, `lower`, `lstrip`, `replace`, `rstrip`, `strip`, `upper`, `zfill`

--- a/tests/integration/secrets.py
+++ b/tests/integration/secrets.py
@@ -7,6 +7,15 @@ from os.path import join
 from bundlewrap.utils.testing import make_repo, run
 
 
+def test_b64encode_fault(tmpdir):
+    make_repo(tmpdir)
+
+    stdout, stderr, rcode = run("bw debug -c 'print(repo.vault.password_for(\"testing\").b64encode())'", path=str(tmpdir))
+    assert stdout == b"ZmFDVFQ3NmthZ3REdVpFNXdub2lEMUN4aEdLbWJnaVg=\n"
+    assert stderr == b""
+    assert rcode == 0
+
+
 def test_encrypt(tmpdir):
     make_repo(tmpdir)
 


### PR DESCRIPTION
We have *a lot* of these in our k8s stuff:

```python
k8s_secrets = {
    'foo': {
        'context': {
            'username': b64encode(str(teamvault.username('1234')).encode('UTF-8')).decode('UTF-8'),
        },
        'manifest_file': 'foo.yaml',
        'manifest_processor': 'mako',
    },
}
```

That's wrong because Faults will get resolved too early … so, that b64encode dance must be done in the template. That's pretty noisy and a little annoying. :)

With this PR, you can do the following and be done with it:

```python
k8s_secrets = {
    'foo': {
        'context': {
            'username': teamvault.username('1234').b64encode(),
        },
        'manifest_file': 'foo.yaml',
        'manifest_processor': 'mako',
    },
}
```