### PR TITLE
Fault: Resolve recursively

### DIFF
--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -87,6 +87,8 @@ class Fault(object):
         if self._available is None:
             try:
                 self._value = self.callback(**self.kwargs)
+                if isinstance(self._value, Fault):
+                    self._value = self._value.value
                 self._available = True
             except FaultUnavailable as exc:
                 self._available = False


### PR DESCRIPTION
Fixes issues with nested Faults of different nesting levels. For
example:

    from bundlewrap.utils import Fault

    def wrap(something):
        def callback():
            return something
        return Fault(callback)

    foo_level1 = wrap('foo')
    bar_level1 = wrap('bar')

    bar_level2 = wrap(bar_level1)

    res = foo_level1 + bar_level2
    print(res)

Resulted in the following Exception:

    TypeError: can only concatenate str (not "Fault") to str