### PR TITLE
Fault: Implement __lt__

### DIFF
--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -107,6 +107,9 @@ class Fault(object):
     def __len__(self):
         return len(self.value)
 
+    def __lt__(self, other):
+        return self.value < other.value
+
     def __str__(self):
         return str(self.value)
 


### PR DESCRIPTION
You can't sort a list of Faults in templates without this.