### PR TITLE
Add repo.vault.random_bytes_as_base64_for()

### DIFF
--- a/bundlewrap/secrets.py
+++ b/bundlewrap/secrets.py
@@ -219,6 +219,13 @@ class SecretProxy(object):
 
         return "".join([choice_prng(alphabet, prng) for i in range(length)])
 
+    def _generate_random_bytes_as_base64(self, identifier=None, key='generate', length=32):
+        if environ.get("BW_VAULT_DUMMY_MODE", "0") != "0":
+            return b64encode(bytearray([ord("a") for i in range(length)])).decode()
+
+        prng = self._get_prng(identifier, key)
+        return b64encode(bytearray([next(prng) for i in range(length)])).decode()
+
     def _get_prng(self, identifier, key):
         try:
             key_encoded = self.keys[key]
@@ -332,4 +339,12 @@ class SecretProxy(object):
             key=key,
             length=length,
             symbols=symbols,
+        )
+
+    def random_bytes_as_base64_for(self, identifier, key='generate', length=32):
+        return Fault(
+            self._generate_random_bytes_as_base64,
+            identifier=identifier,
+            key=key,
+            length=length,
         )

--- a/docs/content/guide/secrets.md
+++ b/docs/content/guide/secrets.md
@@ -42,6 +42,16 @@ This makes it easy to change all your passwords at once (e.g. when an employee l
 
 As an alternative to `password_for()`, which generates random strings, you can use `human_password_for()`.It generates strings like `Wiac-Kaobl-Teuh-Kumd-40`. They are easier to handle for human beings. You might want to use them if you have to type those passwords on a regular basis.
 
+### Random bytes
+
+`password_for()` and `human_password_for()` are meant for passwords. If you need plain random bytes, you can use `random_bytes_as_base64_for()`. As the name implies, it will return the data base64 encoded. Some examples:
+
+<pre><code class="nohighlight">$ bw debug -c 'print(repo.vault.random_bytes_as_base64_for("foo"))'
+qczM0GUKW7YlXEuW8HGPYkjCGaX4Vu9Fja5SIZWga7w=
+$ bw debug -c 'print(repo.vault.random_bytes_as_base64_for("foo", length=1))'
+qQ==
+</code></pre>
+
 <br>
 
 ## Static passwords

--- a/tests/integration/secrets.py
+++ b/tests/integration/secrets.py
@@ -128,3 +128,21 @@ def test_human_password_words(tmpdir):
     assert stdout == b"Xaint-Heep-13\n"
     assert stderr == b""
     assert rcode == 0
+
+
+def test_random_bytes_as_base64(tmpdir):
+    make_repo(tmpdir)
+
+    stdout, stderr, rcode = run("bw debug -c 'print(repo.vault.random_bytes_as_base64_for(\"foo\"))'", path=str(tmpdir))
+    assert stdout == b"rt+Dgv0yA10DS3ux94mmtEg+isChTJvgkfklzmWkvyg=\n"
+    assert stderr == b""
+    assert rcode == 0
+
+
+def test_random_bytes_as_base64_length(tmpdir):
+    make_repo(tmpdir)
+
+    stdout, stderr, rcode = run("bw debug -c 'print(repo.vault.random_bytes_as_base64_for(\"foo\", length=1))'", path=str(tmpdir))
+    assert stdout == b"rg==\n"
+    assert stderr == b""
+    assert rcode == 0


### PR DESCRIPTION
For when you just need some random bytes that are derived from an
identifier.

Faults are expected to wrap other Faults or 'str', but not plain bytes,
so we always have to b64encode our data.