### PR TITLE
Metaprocs: Detect when users return an original metadata object with an invalid flag

### DIFF
--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -93,7 +93,7 @@ def check_metadata_keys(node):
             ))
 
 
-def check_metadata_processor_result(result, node_name, metadata_processor_name):
+def check_metadata_processor_result(input_metadata, result, node_name, metadata_processor_name):
     """
     Validates the return value of a metadata processor and splits it
     into metadata and options.
@@ -111,6 +111,17 @@ def check_metadata_processor_result(result, node_name, metadata_processor_name):
         raise ValueError(_(
             "metadata processor {metaproc} for node {node} did not return "
             "a dict as the first element"
+        ).format(
+            metaproc=metadata_processor_name,
+            node=node_name,
+        ))
+    if (
+        (DEFAULTS in options or OVERWRITE in options) and
+        id(input_metadata) == id(result_dict)
+    ):
+        raise ValueError(_(
+            "metadata processor {metaproc} for node {node} returned original "
+            "metadata dict plus DEFAULTS or OVERWRITE"
         ).format(
             metaproc=metadata_processor_name,
             node=node_name,

--- a/bundlewrap/repo.py
+++ b/bundlewrap/repo.py
@@ -577,6 +577,7 @@ class Repository(object):
                             ))
                             raise exc
                         processed_dict, options = check_metadata_processor_result(
+                            input_metadata,
                             processed,
                             node.name,
                             metadata_processor_name,

--- a/docs/content/repo/metadata.py.md
+++ b/docs/content/repo/metadata.py.md
@@ -36,8 +36,8 @@ In this example, `"bar"` can only be set once `"foo"` is available and thus the 
 <tr><th>Option</th><th>Description</th></tr>
 <tr><td><code>DONE</code></td><td>Indicates that this metadata processor has done all it can and need not be called again. Return this whenever possible.</td></tr>
 <tr><td><code>RUN_ME_AGAIN</code></td><td>Indicates that this metadata processor is still waiting for metadata from another metadata processor to become available.</td></tr>
-<tr><td><code>DEFAULTS</code></td><td>The returned metadata dictionary will only be used to provide default values. The actual metadata generated so far will be recursively merged into the returned dict.</td></tr>
-<tr><td><code>OVERWRITE</code></td><td>The returned metadata dictionary will be recursively merged into the actual metadata generated so far (inverse of <code>DEFAULTS</code>).</td></tr>
+<tr><td><code>DEFAULTS</code></td><td>The returned metadata dictionary will only be used to provide default values. The actual metadata generated so far will be recursively merged into the returned dict. When using this flag, you must not return the original metadata dictionary but construct a new one as in the example below.</td></tr>
+<tr><td><code>OVERWRITE</code></td><td>The returned metadata dictionary will be recursively merged into the actual metadata generated so far (inverse of <code>DEFAULTS</code>). When using this flag, you must not return the original metadata dictionary but construct a new one as in the `DEFAULTS` example below.</td></tr>
 </table>
 
 Here is an example of how to use `DEFAULTS`:

--- a/tests/integration/bw_metadata.py
+++ b/tests/integration/bw_metadata.py
@@ -258,6 +258,174 @@ def foo(metadata):
     assert rcode == 0
 
 
+def test_metadatapy_invalid_number_of_elements(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={"test": {}},
+        nodes={
+            "node1": {
+                'bundles': ["test"],
+                'metadata': {"foo": "bar"},
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "metadata.py"), 'w') as f:
+        f.write(
+"""@metadata_processor
+def foo(metadata):
+    return metadata
+""")
+    stdout, stderr, rcode = run("bw metadata node1", path=str(tmpdir))
+    assert rcode != 0
+
+
+def test_metadatapy_invalid_first_element_not_dict(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={"test": {}},
+        nodes={
+            "node1": {
+                'bundles': ["test"],
+                'metadata': {"foo": "bar"},
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "metadata.py"), 'w') as f:
+        f.write(
+"""@metadata_processor
+def foo(metadata):
+    return DONE, metadata
+""")
+    stdout, stderr, rcode = run("bw metadata node1", path=str(tmpdir))
+    assert rcode != 0
+
+
+def test_metadatapy_invalid_defaults_plus_original_dict(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={"test": {}},
+        nodes={
+            "node1": {
+                'bundles': ["test"],
+                'metadata': {"foo": "bar"},
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "metadata.py"), 'w') as f:
+        f.write(
+"""@metadata_processor
+def foo(metadata):
+    return metadata, DONE, DEFAULTS
+""")
+    stdout, stderr, rcode = run("bw metadata node1", path=str(tmpdir))
+    assert rcode != 0
+
+
+def test_metadatapy_invalid_overwrite_plus_original_dict(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={"test": {}},
+        nodes={
+            "node1": {
+                'bundles': ["test"],
+                'metadata': {"foo": "bar"},
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "metadata.py"), 'w') as f:
+        f.write(
+"""@metadata_processor
+def foo(metadata):
+    return metadata, DONE, OVERWRITE
+""")
+    stdout, stderr, rcode = run("bw metadata node1", path=str(tmpdir))
+    assert rcode != 0
+
+
+def test_metadatapy_invalid_option(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={"test": {}},
+        nodes={
+            "node1": {
+                'bundles': ["test"],
+                'metadata': {"foo": "bar"},
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "metadata.py"), 'w') as f:
+        f.write(
+"""@metadata_processor
+def foo(metadata):
+    return metadata, DONE, 1000
+""")
+    stdout, stderr, rcode = run("bw metadata node1", path=str(tmpdir))
+    assert rcode != 0
+
+
+def test_metadatapy_invalid_done_and_again(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={"test": {}},
+        nodes={
+            "node1": {
+                'bundles': ["test"],
+                'metadata': {"foo": "bar"},
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "metadata.py"), 'w') as f:
+        f.write(
+"""@metadata_processor
+def foo(metadata):
+    return metadata, DONE, RUN_ME_AGAIN
+""")
+    stdout, stderr, rcode = run("bw metadata node1", path=str(tmpdir))
+    assert rcode != 0
+
+
+def test_metadatapy_invalid_no_done_or_again(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={"test": {}},
+        nodes={
+            "node1": {
+                'bundles': ["test"],
+                'metadata': {"foo": "bar"},
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "metadata.py"), 'w') as f:
+        f.write(
+"""@metadata_processor
+def foo(metadata):
+    return {}, DEFAULTS
+""")
+    stdout, stderr, rcode = run("bw metadata node1", path=str(tmpdir))
+    assert rcode != 0
+
+
+def test_metadatapy_invalid_defaults_and_overwrite(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={"test": {}},
+        nodes={
+            "node1": {
+                'bundles': ["test"],
+                'metadata': {"foo": "bar"},
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "metadata.py"), 'w') as f:
+        f.write(
+"""@metadata_processor
+def foo(metadata):
+    return {}, DEFAULTS, OVERWRITE, DONE
+""")
+    stdout, stderr, rcode = run("bw metadata node1", path=str(tmpdir))
+    assert rcode != 0
+
+
 def test_table(tmpdir):
     make_repo(
         tmpdir,


### PR DESCRIPTION
This is illegal because it can result in duplicate metadata, like
merging lists in merge_dict().