### PR TITLE
Fix KeyError in kubernetes item

### DIFF
--- a/bundlewrap/items/kubernetes.py
+++ b/bundlewrap/items/kubernetes.py
@@ -244,6 +244,7 @@ class KubernetesRawItem(KubernetesItem):
                     bundle=self.bundle.name,
                     item2=item.id,
                     bundle2=item.bundle.name,
+                    node=self.node.name,
                 ))
 
     def get_auto_deps(self, items):


### PR DESCRIPTION
This PR fixes a KeyError that occurs when triggering the duplicate definition BundleError in the kubernetes item.

``` 
File "/usr/local/lib/python3.7/site-packages/bundlewrap/items/kubernetes.py", line 246, in _check_bundle_collisions
    bundle2=item.bundle.name,
KeyError: 'node'
```