### PR TITLE
k8s: Bump apiVersions

### DIFF
--- a/bundlewrap/items/kubernetes.py
+++ b/bundlewrap/items/kubernetes.py
@@ -310,7 +310,7 @@ class KubernetesCronJob(KubernetesItem):
 class KubernetesCustomResourceDefinition(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_crd"
     KIND = "CustomResourceDefinition"
-    KUBERNETES_APIVERSION = "apiextensions.k8s.io/v1beta1"
+    KUBERNETES_APIVERSION = "apiextensions.k8s.io/v1"
     ITEM_TYPE_NAME = "k8s_crd"
     NAME_REGEX = r"^[a-z0-9-\.]{1,253}$"
     NAME_REGEX_COMPILED = re.compile(NAME_REGEX)
@@ -326,7 +326,7 @@ class KubernetesCustomResourceDefinition(KubernetesItem):
 class KubernetesDaemonSet(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_daemonsets"
     KIND = "DaemonSet"
-    KUBERNETES_APIVERSION = "v1"
+    KUBERNETES_APIVERSION = "apps/v1"
     ITEM_TYPE_NAME = "k8s_daemonset"
 
     def get_auto_deps(self, items):
@@ -343,7 +343,7 @@ class KubernetesDaemonSet(KubernetesItem):
 class KubernetesDeployment(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_deployments"
     KIND = "Deployment"
-    KUBERNETES_APIVERSION = "extensions/v1beta1"
+    KUBERNETES_APIVERSION = "apps/v1"
     ITEM_TYPE_NAME = "k8s_deployment"
 
     def get_auto_deps(self, items):
@@ -360,7 +360,7 @@ class KubernetesDeployment(KubernetesItem):
 class KubernetesIngress(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_ingresses"
     KIND = "Ingress"
-    KUBERNETES_APIVERSION = "extensions/v1beta1"
+    KUBERNETES_APIVERSION = "networking.k8s.io/v1beta1"
     ITEM_TYPE_NAME = "k8s_ingress"
 
     def get_auto_deps(self, items):


### PR DESCRIPTION
All apiVersions have been bumped to what's currently listed on
kubernetes.io.

Careful: It appears you can't change the apiVersion of already deployed
objects, so you must re-deploy all affected objects.