### PR TITLE
k8s_*: No longer provide default for apiVersion

### DIFF
--- a/bundlewrap/items/kubernetes.py
+++ b/bundlewrap/items/kubernetes.py
@@ -38,7 +38,6 @@ class KubernetesItem(Item):
         'context': None,
     }
     KIND = None
-    KUBERNETES_APIVERSION = "v1"
     NAME_REGEX = r"^[a-z0-9-\.]{1,253}/[a-z0-9-\.]{1,253}$"
     NAME_REGEX_COMPILED = re.compile(NAME_REGEX)
 
@@ -131,7 +130,6 @@ class KubernetesItem(Item):
 
         merged_manifest = merge_dict(
             {
-                'apiVersion': self.KUBERNETES_APIVERSION,
                 'kind': self.KIND,
                 'metadata': {
                     'name': self.name.split("/")[-1],
@@ -232,7 +230,6 @@ class KubernetesItem(Item):
 class KubernetesRawItem(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_raw"
     ITEM_TYPE_NAME = "k8s_raw"
-    KUBERNETES_APIVERSION = None
     NAME_REGEX = r"^([a-z0-9-\.]{1,253})?/[a-zA-Z0-9-\.]{1,253}/[a-z0-9-\.]{1,253}$"
     NAME_REGEX_COMPILED = re.compile(NAME_REGEX)
 
@@ -271,7 +268,6 @@ class KubernetesRawItem(KubernetesItem):
 class KubernetesClusterRole(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_clusterroles"
     KIND = "ClusterRole"
-    KUBERNETES_APIVERSION = "rbac.authorization.k8s.io/v1"
     ITEM_TYPE_NAME = "k8s_clusterrole"
     NAME_REGEX = r"^[a-z0-9-\.]{1,253}$"
     NAME_REGEX_COMPILED = re.compile(NAME_REGEX)
@@ -284,7 +280,6 @@ class KubernetesClusterRole(KubernetesItem):
 class KubernetesClusterRoleBinding(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_clusterrolebindings"
     KIND = "ClusterRoleBinding"
-    KUBERNETES_APIVERSION = "rbac.authorization.k8s.io/v1"
     ITEM_TYPE_NAME = "k8s_clusterrolebinding"
     NAME_REGEX = r"^[a-z0-9-\.]{1,253}$"
     NAME_REGEX_COMPILED = re.compile(NAME_REGEX)
@@ -302,21 +297,18 @@ class KubernetesClusterRoleBinding(KubernetesItem):
 class KubernetesConfigMap(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_configmaps"
     KIND = "ConfigMap"
-    KUBERNETES_APIVERSION = "v1"
     ITEM_TYPE_NAME = "k8s_configmap"
 
 
 class KubernetesCronJob(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_cronjobs"
     KIND = "CronJob"
-    KUBERNETES_APIVERSION = "batch/v1beta1"
     ITEM_TYPE_NAME = "k8s_cronjob"
 
 
 class KubernetesCustomResourceDefinition(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_crd"
     KIND = "CustomResourceDefinition"
-    KUBERNETES_APIVERSION = "apiextensions.k8s.io/v1"
     ITEM_TYPE_NAME = "k8s_crd"
     NAME_REGEX = r"^[a-z0-9-\.]{1,253}$"
     NAME_REGEX_COMPILED = re.compile(NAME_REGEX)
@@ -332,7 +324,6 @@ class KubernetesCustomResourceDefinition(KubernetesItem):
 class KubernetesDaemonSet(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_daemonsets"
     KIND = "DaemonSet"
-    KUBERNETES_APIVERSION = "apps/v1"
     ITEM_TYPE_NAME = "k8s_daemonset"
 
     def get_auto_deps(self, items):
@@ -349,7 +340,6 @@ class KubernetesDaemonSet(KubernetesItem):
 class KubernetesDeployment(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_deployments"
     KIND = "Deployment"
-    KUBERNETES_APIVERSION = "apps/v1"
     ITEM_TYPE_NAME = "k8s_deployment"
 
     def get_auto_deps(self, items):
@@ -366,7 +356,6 @@ class KubernetesDeployment(KubernetesItem):
 class KubernetesIngress(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_ingresses"
     KIND = "Ingress"
-    KUBERNETES_APIVERSION = "networking.k8s.io/v1beta1"
     ITEM_TYPE_NAME = "k8s_ingress"
 
     def get_auto_deps(self, items):
@@ -383,7 +372,6 @@ class KubernetesIngress(KubernetesItem):
 class KubernetesNamespace(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_namespaces"
     KIND = "Namespace"
-    KUBERNETES_APIVERSION = "v1"
     ITEM_TYPE_NAME = "k8s_namespace"
     NAME_REGEX = r"^[a-z0-9-\.]{1,253}$"
     NAME_REGEX_COMPILED = re.compile(NAME_REGEX)
@@ -395,7 +383,6 @@ class KubernetesNamespace(KubernetesItem):
 class KubernetesNetworkPolicy(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_networkpolicies"
     KIND = "NetworkPolicy"
-    KUBERNETES_APIVERSION = "networking.k8s.io/v1"
     ITEM_TYPE_NAME = "k8s_networkpolicy"
     NAME_REGEX = r"^([a-z0-9-\.]{1,253})?/[a-z0-9-\.]{1,253}$"
     NAME_REGEX_COMPILED = re.compile(NAME_REGEX)
@@ -404,21 +391,18 @@ class KubernetesNetworkPolicy(KubernetesItem):
 class KubernetesPersistentVolumeClain(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_pvc"
     KIND = "PersistentVolumeClaim"
-    KUBERNETES_APIVERSION = "v1"
     ITEM_TYPE_NAME = "k8s_pvc"
 
 
 class KubernetesRole(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_roles"
     KIND = "Role"
-    KUBERNETES_APIVERSION = "rbac.authorization.k8s.io/v1"
     ITEM_TYPE_NAME = "k8s_role"
 
 
 class KubernetesRoleBinding(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_rolebindings"
     KIND = "RoleBinding"
-    KUBERNETES_APIVERSION = "rbac.authorization.k8s.io/v1"
     ITEM_TYPE_NAME = "k8s_rolebinding"
 
     def get_auto_deps(self, items):
@@ -430,7 +414,6 @@ class KubernetesRoleBinding(KubernetesItem):
 class KubernetesSecret(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_secrets"
     KIND = "Secret"
-    KUBERNETES_APIVERSION = "v1"
     ITEM_TYPE_NAME = "k8s_secret"
 
     def get_auto_deps(self, items):
@@ -440,21 +423,18 @@ class KubernetesSecret(KubernetesItem):
 class KubernetesService(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_services"
     KIND = "Service"
-    KUBERNETES_APIVERSION = "v1"
     ITEM_TYPE_NAME = "k8s_service"
 
 
 class KubernetesServiceAccount(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_serviceaccounts"
     KIND = "ServiceAccount"
-    KUBERNETES_APIVERSION = "v1"
     ITEM_TYPE_NAME = "k8s_serviceaccount"
 
 
 class KubernetesStatefulSet(KubernetesItem):
     BUNDLE_ATTRIBUTE_NAME = "k8s_statefulsets"
     KIND = "StatefulSet"
-    KUBERNETES_APIVERSION = "apps/v1"
     ITEM_TYPE_NAME = "k8s_statefulset"
 
     def get_auto_deps(self, items):

--- a/docs/content/guide/kubernetes.md
+++ b/docs/content/guide/kubernetes.md
@@ -66,7 +66,7 @@ You can then proceed to write bundles as with regular nodes, but using the [k8s_
         },
     }
 
-All item names (except namespaces themselves) must be prefixed with the name of a namespace and a forward slash `/`. Note that BundleWrap will include defaults for the `apiVersion`, `Kind`, and `metadata/name` keys, but you can override them if you must.
+All item names (except namespaces themselves) must be prefixed with the name of a namespace and a forward slash `/`. Note that BundleWrap will include defaults for the `Kind` and `metadata/name` keys, but you can override them if you must.
 
 Alternatively, you can keep your resource definitions in manifest files:
 

--- a/docs/content/items/k8s.md
+++ b/docs/content/items/k8s.md
@@ -9,7 +9,11 @@ See also: [Guide to Kubernetes](../guide/kubernetes.md)
 Manage resources in Kubernetes clusters.
 
     k8s_namespaces = {
-         "my-app": {},
+         "my-app": {
+            'manifest': {
+                'apiVersion': "v1",
+            },
+         },
          "my-previous-app": {'delete': True},
     }
 
@@ -28,25 +32,25 @@ Note that the names of all items in a namespace must be prefixed with the name o
 ## Resource types
 
 <table>
-<tr><th>Resource type</th><th>Bundle attribute</th><th>apiVersion</th></tr>
-<tr><td>Cluster Role</td><td>k8s_clusterroles</td><td>rbac.authorization.k8s.io/v1</td></tr>
-<tr><td>Cluster Role Binding</td><td>k8s_clusterrolebindings</td><td>rbac.authorization.k8s.io/v1</td></tr>
-<tr><td>Config Map</td><td>k8s_configmaps</td><td>v1</td></tr>
-<tr><td>Cron Job</td><td>k8s_cronjobs</td><td>batch/v1beta1</td></tr>
-<tr><td>Custom Resource Definition</td><td>k8s_crd</td><td>apiextensions.k8s.io/v1</td></tr>
-<tr><td>Daemon Set</td><td>k8s_daemonsets</td><td>apps/v1</td></tr>
-<tr><td>Deployment</td><td>k8s_deployments</td><td>apps/v1</td></tr>
-<tr><td>Ingress</td><td>k8s_ingresses</td><td>networking.k8s.io/v1beta1</td></tr>
-<tr><td>Namespace</td><td>k8s_namespaces</td><td>v1</td></tr>
-<tr><td>Network Policy</td><td>k8s_networkpolicies</td><td>networking.k8s.io/v1</td></tr>
-<tr><td>Persistent Volume Claim</td><td>k8s_pvc</td><td>v1</td></tr>
-<tr><td>Role</td><td>k8s_roles</td><td>rbac.authorization.k8s.io/v1</td></tr>
-<tr><td>Role Binding</td><td>k8s_rolebindings</td><td>rbac.authorization.k8s.io/v1</td></tr>
-<tr><td>Service</td><td>k8s_services</td><td>v1</td></tr>
-<tr><td>Service Account</td><td>k8s_serviceaccounts</td><td>v1</td></tr>
-<tr><td>Secret</td><td>k8s_secrets</td><td>v1</td></tr>
-<tr><td>StatefulSet</td><td>k8s_statefulsets</td><td>apps/v1</td></tr>
-<tr><td>(any)</td><td>k8s_raw</td><td>(any)</td></tr>
+<tr><th>Resource type</th><th>Bundle attribute</th></tr>
+<tr><td>Cluster Role</td><td>k8s_clusterroles</td></tr>
+<tr><td>Cluster Role Binding</td><td>k8s_clusterrolebindings</td></tr>
+<tr><td>Config Map</td><td>k8s_configmaps</td></tr>
+<tr><td>Cron Job</td><td>k8s_cronjobs</td></tr>
+<tr><td>Custom Resource Definition</td><td>k8s_crd</td></tr>
+<tr><td>Daemon Set</td><td>k8s_daemonsets</td></tr>
+<tr><td>Deployment</td><td>k8s_deployments</td></tr>
+<tr><td>Ingress</td><td>k8s_ingresses</td></tr>
+<tr><td>Namespace</td><td>k8s_namespaces</td></tr>
+<tr><td>Network Policy</td><td>k8s_networkpolicies</td></tr>
+<tr><td>Persistent Volume Claim</td><td>k8s_pvc</td></tr>
+<tr><td>Role</td><td>k8s_roles</td></tr>
+<tr><td>Role Binding</td><td>k8s_rolebindings</td></tr>
+<tr><td>Service</td><td>k8s_services</td></tr>
+<tr><td>Service Account</td><td>k8s_serviceaccounts</td></tr>
+<tr><td>Secret</td><td>k8s_secrets</td></tr>
+<tr><td>StatefulSet</td><td>k8s_statefulsets</td></tr>
+<tr><td>(any)</td><td>k8s_raw</td></tr>
 </table>
 
 You can define [Custom Resources](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) like this:
@@ -54,6 +58,7 @@ You can define [Custom Resources](https://kubernetes.io/docs/concepts/api-extens
     k8s_crd = {
         "custom-thing": {
             'manifest': {
+                'apiVersion': "apiextensions.k8s.io/v1beta1",
                 'spec': {
                     'names': {
                         'kind': "CustomThing",


### PR DESCRIPTION
CC #488.

Providing a default is meaningless, if we don't also validate that the
objects actually comply with that version.