### PR TITLE
[RFC] Faults get identifiers to be comparable

### DIFF
--- a/bundlewrap/secrets.py
+++ b/bundlewrap/secrets.py
@@ -251,6 +251,7 @@ class SecretProxy:
 
     def decrypt(self, cryptotext, key=None):
         return Fault(
+            'bw secrets decrypt {} {}'.format(cryptotext, key),
             self._decrypt,
             cryptotext=cryptotext,
             key=key,
@@ -258,6 +259,7 @@ class SecretProxy:
 
     def decrypt_file(self, source_path, key=None):
         return Fault(
+            'bw secrets decrypt_file {} {}'.format(source_path, key),
             self._decrypt_file,
             source_path=source_path,
             key=key,
@@ -265,6 +267,7 @@ class SecretProxy:
 
     def decrypt_file_as_base64(self, source_path, key=None):
         return Fault(
+            'bw secrets decrypt_file_as_base64 {} {}'.format(source_path, key),
             self._decrypt_file_as_base64,
             source_path=source_path,
             key=key,
@@ -319,6 +322,13 @@ class SecretProxy:
         self._call_log.setdefault(identifier, 0)
         self._call_log[identifier] += 1
         return Fault(
+            'bw secrets human_password {} {} {} {} {}'.format(
+                identifier,
+                digits,
+                key,
+                per_word,
+                words,
+            ),
             self._generate_human_password,
             identifier=identifier,
             digits=digits,
@@ -331,6 +341,12 @@ class SecretProxy:
         self._call_log.setdefault(identifier, 0)
         self._call_log[identifier] += 1
         return Fault(
+            'bw secrets password {} {} {} {}'.format(
+                identifier,
+                key,
+                length,
+                symbols,
+            ),
             self._generate_password,
             identifier=identifier,
             key=key,
@@ -340,6 +356,11 @@ class SecretProxy:
 
     def random_bytes_as_base64_for(self, identifier, key='generate', length=32):
         return Fault(
+            'bw secrets random_bytes_as_base64 {} {} {}'.format(
+                identifier,
+                key,
+                length,
+            ),
             self._generate_random_bytes_as_base64,
             identifier=identifier,
             key=key,

--- a/bundlewrap/secrets.py
+++ b/bundlewrap/secrets.py
@@ -251,7 +251,7 @@ class SecretProxy:
 
     def decrypt(self, cryptotext, key=None):
         return Fault(
-            'bw secrets decrypt {} {}'.format(cryptotext, key),
+            'bw secrets decrypt',
             self._decrypt,
             cryptotext=cryptotext,
             key=key,
@@ -259,7 +259,7 @@ class SecretProxy:
 
     def decrypt_file(self, source_path, key=None):
         return Fault(
-            'bw secrets decrypt_file {} {}'.format(source_path, key),
+            'bw secrets decrypt_file',
             self._decrypt_file,
             source_path=source_path,
             key=key,
@@ -267,7 +267,7 @@ class SecretProxy:
 
     def decrypt_file_as_base64(self, source_path, key=None):
         return Fault(
-            'bw secrets decrypt_file_as_base64 {} {}'.format(source_path, key),
+            'bw secrets decrypt_file_as_base64',
             self._decrypt_file_as_base64,
             source_path=source_path,
             key=key,
@@ -322,13 +322,7 @@ class SecretProxy:
         self._call_log.setdefault(identifier, 0)
         self._call_log[identifier] += 1
         return Fault(
-            'bw secrets human_password {} {} {} {} {}'.format(
-                identifier,
-                digits,
-                key,
-                per_word,
-                words,
-            ),
+            'bw secrets human_password_for',
             self._generate_human_password,
             identifier=identifier,
             digits=digits,
@@ -341,12 +335,7 @@ class SecretProxy:
         self._call_log.setdefault(identifier, 0)
         self._call_log[identifier] += 1
         return Fault(
-            'bw secrets password {} {} {} {}'.format(
-                identifier,
-                key,
-                length,
-                symbols,
-            ),
+            'bw secrets password_for',
             self._generate_password,
             identifier=identifier,
             key=key,
@@ -356,11 +345,7 @@ class SecretProxy:
 
     def random_bytes_as_base64_for(self, identifier, key='generate', length=32):
         return Fault(
-            'bw secrets random_bytes_as_base64 {} {} {}'.format(
-                identifier,
-                key,
-                length,
-            ),
+            'bw secrets random_bytes_as_base64',
             self._generate_random_bytes_as_base64,
             identifier=identifier,
             key=key,

--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -109,7 +109,7 @@ class Fault:
         else:
             def callback():
                 return self.value + other
-            return Fault(self.id_list + ['raw {}'.format(other)], callback)
+            return Fault(self.id_list + ['raw {}'.format(repr(other))], callback)
 
     def __eq__(self, other):
         if not isinstance(other, Fault):

--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -79,6 +79,11 @@ class Fault:
             self.id_list = fault_identifier
         else:
             self.id_list = [fault_identifier]
+
+        for key, value in sorted(kwargs.items()):
+            self.id_list.append(hash(key))
+            self.id_list.append(hash(value))
+
         self._available = None
         self._exc = None
         self._value = None

--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -109,7 +109,7 @@ class Fault:
         else:
             def callback():
                 return self.value + other
-            return Fault(self.id_list + ['raw ' + other], callback)
+            return Fault(self.id_list + ['raw {}'.format(other)], callback)
 
     def __eq__(self, other):
         if not isinstance(other, Fault):

--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -74,7 +74,11 @@ class Fault:
     This let's us gracefully skip items that require information that's
     currently not available.
     """
-    def __init__(self, callback, **kwargs):
+    def __init__(self, fault_identifier, callback, **kwargs):
+        if isinstance(fault_identifier, list):
+            self.id_list = fault_identifier
+        else:
+            self.id_list = [fault_identifier]
         self._available = None
         self._exc = None
         self._value = None
@@ -96,21 +100,20 @@ class Fault:
         if isinstance(other, Fault):
             def callback():
                 return self.value + other.value
-            return Fault(callback)
+            return Fault(self.id_list + other.id_list, callback)
         else:
             def callback():
                 return self.value + other
-            return Fault(callback)
+            return Fault(self.id_list + ['raw ' + other], callback)
 
     def __eq__(self, other):
-        """
-        Always consider Faults as equal. It would arguably be more
-        correct to always assume them to be different, but that would
-        mean that we could never do change detection between two dicts
-        of metadata. So we have no choice but to warn users in docs that
-        Faults will always be considered equal to one another.
-        """
-        return isinstance(other, Fault)
+        if not isinstance(other, Fault):
+            return False
+        else:
+            return self.id_list == other.id_list
+
+    def __hash__(self):
+        return hash(tuple(self.id_list))
 
     def __len__(self):
         return len(self.value)
@@ -124,12 +127,12 @@ class Fault:
     def b64encode(self):
         def callback():
             return b64encode(self.value.encode('UTF-8')).decode('UTF-8')
-        return Fault(callback)
+        return Fault(self.id_list + ['b64encode'], callback)
 
     def format_into(self, format_string):
         def callback():
             return format_string.format(self.value)
-        return Fault(callback)
+        return Fault(self.id_list + ['format_into ' + format_string], callback)
 
     @property
     def is_available(self):
@@ -148,7 +151,7 @@ def _make_method_callback(method_name):
     def method(self, *args, **kwargs):
         def callback():
             return getattr(self.value, method_name)(*args, **kwargs)
-        return Fault(callback)
+        return Fault(self.id_list + [method_name], callback)
     return method
 
 

--- a/docs/content/repo/metadata.py.md
+++ b/docs/content/repo/metadata.py.md
@@ -32,8 +32,6 @@ While node and group metadata and metadata defaults will always be available to 
 
 To avoid deadlocks when accessing *other* nodes' metadata from within a metadata reactor, use `other_node.partial_metadata` instead of `other_node.metadata`. For the same reason, always use the `metadata` parameter to access the current node's metadata, never `node.metadata`.
 
-<div class="alert alert-danger">Be careful when returning <a href="../../guide/api#bundlewraputilsfault">Fault</a> objects from reactors. <strong>All</strong> Fault objects (including those returned from <code>repo.vault.*</code>) will be considered <strong>equal</strong> to one another when BundleWrap inspects the returned metadata to check if anything changed compared to what was returned in an earlier iteration.</div>
-
 
 ### DoNotRunAgain
 

--- a/tests/integration/secret.py
+++ b/tests/integration/secret.py
@@ -185,3 +185,238 @@ def test_random_bytes_as_base64_length(tmpdir):
     assert stdout == b"rg==\n"
     assert stderr == b""
     assert rcode == 0
+
+
+def test_faults_equality_decrypt(tmpdir):
+    make_repo(tmpdir)
+
+    stdout, stderr, rcode = run("bw debug -c 'print(repo.vault.encrypt(\"foo\"))'", path=str(tmpdir))
+    assert stderr == b""
+    assert rcode == 0
+    enc_foo = stdout.decode('utf-8').strip()
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.encrypt(\"bar\"))'", path=str(tmpdir),
+    )
+    assert stderr == b""
+    assert rcode == 0
+    enc_bar = stdout.decode('utf-8').strip()
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.decrypt(\"{}\") == repo.vault.decrypt(\"{}\"))'".format(
+            enc_foo, enc_foo,
+        ),
+        path=str(tmpdir),
+    )
+    assert stdout == b"True\n"
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.decrypt(\"{}\") == repo.vault.decrypt(\"{}\"))'".format(
+            enc_foo, enc_bar,
+        ),
+        path=str(tmpdir),
+    )
+    assert stdout == b"False\n"
+    assert stderr == b""
+    assert rcode == 0
+
+
+def test_faults_equality_decrypt_file(tmpdir):
+    make_repo(tmpdir)
+
+    source_file = join(str(tmpdir), "data", "source")
+    with open(source_file, 'w') as f:
+        f.write("foo")
+    stdout, stderr, rcode = run(
+        "bw debug -c 'repo.vault.encrypt_file(\"{}\", \"{}\")'".format(
+            source_file,
+            "enc_foo",
+        ),
+        path=str(tmpdir),
+    )
+    assert stderr == b""
+    assert rcode == 0
+
+    source_file = join(str(tmpdir), "data", "source")
+    with open(source_file, 'w') as f:
+        f.write("bar")
+    stdout, stderr, rcode = run(
+        "bw debug -c 'repo.vault.encrypt_file(\"{}\", \"{}\")'".format(
+            source_file,
+            "enc_bar",
+        ),
+        path=str(tmpdir),
+    )
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.decrypt_file(\"{}\") == repo.vault.decrypt_file(\"{}\"))'".format(
+            "enc_foo", "enc_foo",
+        ),
+        path=str(tmpdir),
+    )
+    assert stdout == b"True\n"
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.decrypt_file(\"{}\") == repo.vault.decrypt_file(\"{}\"))'".format(
+            "enc_foo", "enc_bar",
+        ),
+        path=str(tmpdir),
+    )
+    assert stdout == b"False\n"
+    assert stderr == b""
+    assert rcode == 0
+
+
+def test_faults_equality_decrypt_file_as_base64(tmpdir):
+    make_repo(tmpdir)
+
+    source_file = join(str(tmpdir), "data", "source")
+    with open(source_file, 'w') as f:
+        f.write("foo")
+    stdout, stderr, rcode = run(
+        "bw debug -c 'repo.vault.encrypt_file(\"{}\", \"{}\")'".format(
+            source_file,
+            "enc_foo",
+        ),
+        path=str(tmpdir),
+    )
+    assert stderr == b""
+    assert rcode == 0
+
+    source_file = join(str(tmpdir), "data", "source")
+    with open(source_file, 'w') as f:
+        f.write("bar")
+    stdout, stderr, rcode = run(
+        "bw debug -c 'repo.vault.encrypt_file(\"{}\", \"{}\")'".format(
+            source_file,
+            "enc_bar",
+        ),
+        path=str(tmpdir),
+    )
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.decrypt_file_as_base64(\"{}\") == repo.vault.decrypt_file_as_base64(\"{}\"))'".format(
+            "enc_foo", "enc_foo",
+        ),
+        path=str(tmpdir),
+    )
+    assert stdout == b"True\n"
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.decrypt_file_as_base64(\"{}\") == repo.vault.decrypt_file_as_base64(\"{}\"))'".format(
+            "enc_foo", "enc_bar",
+        ),
+        path=str(tmpdir),
+    )
+    assert stdout == b"False\n"
+    assert stderr == b""
+    assert rcode == 0
+
+
+def test_faults_equality_decrypt_file_mixed(tmpdir):
+    make_repo(tmpdir)
+
+    source_file = join(str(tmpdir), "data", "source")
+    with open(source_file, 'w') as f:
+        f.write("foo")
+    stdout, stderr, rcode = run(
+        "bw debug -c 'repo.vault.encrypt_file(\"{}\", \"{}\")'".format(
+            source_file,
+            "enc_foo",
+        ),
+        path=str(tmpdir),
+    )
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.decrypt_file_as_base64(\"{}\") == repo.vault.decrypt_file(\"{}\"))'".format(
+            "enc_foo", "enc_foo",
+        ),
+        path=str(tmpdir),
+    )
+    assert stdout == b"False\n"
+    assert stderr == b""
+    assert rcode == 0
+
+
+def test_faults_equality_human_password_for(tmpdir):
+    make_repo(tmpdir)
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.human_password_for(\"a\") == repo.vault.human_password_for(\"a\"))'",
+        path=str(tmpdir),
+    )
+    assert stdout == b"True\n"
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.human_password_for(\"a\") == repo.vault.human_password_for(\"b\"))'",
+        path=str(tmpdir),
+    )
+    assert stdout == b"False\n"
+    assert stderr == b""
+    assert rcode == 0
+
+
+def test_faults_equality_password_for(tmpdir):
+    make_repo(tmpdir)
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.password_for(\"a\") == repo.vault.password_for(\"a\"))'",
+        path=str(tmpdir),
+    )
+    assert stdout == b"True\n"
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.password_for(\"a\") == repo.vault.password_for(\"b\"))'",
+        path=str(tmpdir),
+    )
+    assert stdout == b"False\n"
+    assert stderr == b""
+    assert rcode == 0
+
+
+def test_faults_equality_password_for_mixed(tmpdir):
+    make_repo(tmpdir)
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.password_for(\"a\") == repo.vault.human_password_for(\"a\"))'",
+        path=str(tmpdir),
+    )
+    assert stdout == b"False\n"
+    assert stderr == b""
+    assert rcode == 0
+
+
+def test_faults_equality_random_bytes_as_base64(tmpdir):
+    make_repo(tmpdir)
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.random_bytes_as_base64_for(\"a\") == repo.vault.random_bytes_as_base64_for(\"a\"))'",
+        path=str(tmpdir),
+    )
+    assert stdout == b"True\n"
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.random_bytes_as_base64_for(\"a\") == repo.vault.random_bytes_as_base64_for(\"b\"))'",
+        path=str(tmpdir),
+    )
+    assert stdout == b"False\n"
+    assert stderr == b""
+    assert rcode == 0

--- a/tests/unit/faults.py
+++ b/tests/unit/faults.py
@@ -219,3 +219,12 @@ def test_can_be_used_in_set():
     assert len(s) == 2
     assert 'foo' in [i.value for i in s]
     assert 'bar' in [i.value for i in s]
+
+
+def test_kwargs_add_to_idlist():
+    def callback():
+        return 'foo'
+
+    a = Fault('id foo', callback, foo='bar', baz='bam', frob='glob')
+    b = Fault('id foo', callback, different='kwargs')
+    assert a != b

--- a/tests/unit/faults.py
+++ b/tests/unit/faults.py
@@ -228,3 +228,14 @@ def test_kwargs_add_to_idlist():
     a = Fault('id foo', callback, foo='bar', baz='bam', frob='glob')
     b = Fault('id foo', callback, different='kwargs')
     assert a != b
+
+
+def test_eq_and_hash_do_not_resolve_fault():
+    def callback():
+        raise Exception('Fault resolved, this should not happen')
+
+    a = Fault('id foo', callback)
+    b = Fault('id foo', callback)
+    assert a == b
+
+    s = {a, b}

--- a/tests/unit/faults.py
+++ b/tests/unit/faults.py
@@ -21,6 +21,27 @@ def test_add_fault():
     assert c.value == 'foobar'
 
 
+def test_add_fault_nonstring():
+    def callback_a():
+        return 4
+    def callback_b():
+        return 8
+
+    a = Fault('id foo', callback_a)
+    b = Fault('id bar', callback_b)
+    c = a + b
+    assert c.value == 12
+
+
+def test_add_plain_nonstring():
+    def callback():
+        return 4
+
+    a = Fault('id foo', callback)
+    b = a + 8
+    assert b.value == 12
+
+
 def test_add_plain():
     def callback_a():
         return 'foo'

--- a/tests/unit/faults.py
+++ b/tests/unit/faults.py
@@ -1,0 +1,75 @@
+from bundlewrap.utils import Fault
+
+
+def test_basic_resolve():
+    def callback():
+        return 4  # Chosen by fair dice roll. Guaranteed to be random.
+
+    f = Fault(callback)
+    assert f.value == 4
+
+
+def test_add_fault():
+    def callback_a():
+        return 'foo'
+    def callback_b():
+        return 'bar'
+
+    a = Fault(callback_a)
+    b = Fault(callback_b)
+    c = a + b
+    assert c.value == 'foobar'
+
+
+def test_add_plain():
+    def callback_a():
+        return 'foo'
+
+    a = Fault(callback_a)
+    c = a + 'bar'
+    assert c.value == 'foobar'
+
+
+def test_order():
+    def callback_a():
+        return 'foo'
+    def callback_b():
+        return 'bar'
+    def callback_c():
+        return '0first'
+
+    a = Fault(callback_a)
+    b = Fault(callback_b)
+    c = Fault(callback_c)
+
+    lst = sorted([a, b, c])
+
+    assert lst[0].value == '0first'
+    assert lst[1].value == 'bar'
+    assert lst[2].value == 'foo'
+
+
+def test_base64():
+    def callback():
+        return 'foo'
+
+    a = Fault(callback).b64encode()
+    assert a.value == 'Zm9v'
+
+
+def test_format_into():
+    def callback():
+        return 'foo'
+
+    a = Fault(callback).format_into('This is my secret: "{}"')
+    assert a.value == 'This is my secret: "foo"'
+
+
+# XXX Other methods missing. This basically tests if
+# _make_method_callback() is working.
+def test_generic_method_lower():
+    def callback():
+        return 'FOO'
+
+    a = Fault(callback)
+    assert a.lower().value == 'foo'


### PR DESCRIPTION
I am not happy with this. It is better than before, but it is very easy to accidentally create collisions, thus making unequal Faults “equal”. It’s just not a fool proof interface.

But how else would you make Faults comparable?