### PR TITLE
add toml nodes and groups

### DIFF
--- a/bundlewrap/cmdline/nodes.py
+++ b/bundlewrap/cmdline/nodes.py
@@ -9,7 +9,7 @@ from ..utils.ui import io, page_lines
 from ..group import GROUP_ATTR_DEFAULTS
 
 
-NODE_ATTRS = sorted(list(GROUP_ATTR_DEFAULTS) + ['bundles', 'groups', 'hostname'])
+NODE_ATTRS = sorted(list(GROUP_ATTR_DEFAULTS) + ['bundles', 'file_path', 'groups', 'hostname'])
 NODE_ATTRS_LISTS = ('bundles', 'groups')
 
 
@@ -23,7 +23,7 @@ def _attribute_table(
 ):
     rows = [[entity_label], ROW_SEPARATOR]
     selected_attrs = [attr.strip() for attr in selected_attrs]
-    if selected_attrs == ['all']:
+    if 'all' in selected_attrs:
         selected_attrs = available_attrs
     for attr in selected_attrs:
         if attr not in available_attrs:

--- a/bundlewrap/group.py
+++ b/bundlewrap/group.py
@@ -1,7 +1,7 @@
 from os.path import join
 import re
 
-from tomlkit import dumps as dump_toml, parse as parse_toml
+from tomlkit import dumps as toml_dump, parse as toml_parse
 
 from .exceptions import NoSuchGroup, NoSuchNode, RepositoryError
 from .utils import cached_property, error_context, get_file_contents, names
@@ -13,7 +13,7 @@ from .utils.dicts import (
     COLLECTION_OF_STRINGS,
     TUPLE_OF_INTS,
 )
-from .utils.text import mark_for_translation as _, validate_name
+from .utils.text import mark_for_translation as _, toml_clean, validate_name
 
 
 GROUP_ATTR_DEFAULTS = {
@@ -213,7 +213,7 @@ class Group:
     def toml(self):
         if not self.file_path or not self.file_path.endswith(".toml"):
             raise ValueError(_("group {} not in TOML format").format(self.name))
-        return parse_toml(get_file_contents(self.file_path))
+        return toml_parse(get_file_contents(self.file_path))
 
     def toml_save(self):
         try:
@@ -224,7 +224,7 @@ class Group:
             toml_doc = dict_to_toml(attributes)
             self.file_path = join(self.repo.path, "groups", self.name + ".toml")
         with open(self.file_path, 'w') as f:
-            f.write(dump_toml(toml_doc))
+            f.write(toml_clean(toml_dump(toml_doc)))
 
     def toml_set(self, path, value):
         if not isinstance(path, tuple):

--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -214,7 +214,7 @@ def check_for_metadata_conflicts_between_groups(node):
     for chain in chains:
         metadata = {}
         for group in chain:
-            metadata = merge_dict(metadata, group.metadata)
+            metadata = merge_dict(metadata, group._attributes.get('metadata', {}))
         chain_metadata.append(metadata)
 
     # create a "key path map" for each chain's metadata
@@ -256,8 +256,12 @@ def find_groups_causing_metadata_conflict(node_name, chain1, chain2, keypath):
     Given two chains (lists of groups), find one group in each chain
     that has conflicting metadata with the other for the given key path.
     """
-    chain1_metadata = [list(map_dict_keys(group.metadata)) for group in chain1]
-    chain2_metadata = [list(map_dict_keys(group.metadata)) for group in chain2]
+    chain1_metadata = [
+        list(map_dict_keys(group._attributes.get('metadata', {}))) for group in chain1
+    ]
+    chain2_metadata = [
+        list(map_dict_keys(group._attributes.get('metadata', {}))) for group in chain2
+    ]
 
     bad_keypath = None
 

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -4,7 +4,7 @@ from os import environ
 from os.path import join
 from threading import Lock
 
-from tomlkit import dumps as dump_toml, parse as parse_toml
+from tomlkit import dumps as toml_dump, parse as toml_parse
 
 from . import operations
 from .bundle import Bundle
@@ -46,6 +46,7 @@ from .utils.text import (
     green,
     mark_for_translation as _,
     red,
+    toml_clean,
     validate_name,
     yellow,
 )
@@ -749,7 +750,7 @@ class Node:
     def toml(self):
         if not self.file_path or not self.file_path.endswith(".toml"):
             raise ValueError(_("node {} not in TOML format").format(self.name))
-        return parse_toml(get_file_contents(self.file_path))
+        return toml_parse(get_file_contents(self.file_path))
 
     def toml_save(self):
         try:
@@ -760,7 +761,7 @@ class Node:
             toml_doc = dict_to_toml(attributes)
             self.file_path = join(self.repo.path, "nodes", self.name + ".toml")
         with open(self.file_path, 'w') as f:
-            f.write(dump_toml(toml_doc))
+            f.write(toml_clean(toml_dump(toml_doc)))
 
     def toml_set(self, path, value):
         if not isinstance(path, tuple):

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -1,7 +1,10 @@
 from datetime import datetime, timedelta
 from hashlib import md5
 from os import environ
+from os.path import join
 from threading import Lock
+
+from tomlkit import dumps as dump_toml, parse as parse_toml
 
 from . import operations
 from .bundle import Bundle
@@ -25,9 +28,11 @@ from .itemqueue import ItemQueue
 from .items import Item
 from .lock import NodeLock
 from .metadata import hash_metadata
-from .utils import cached_property, error_context, names, NO_DEFAULT
+from .utils import cached_property, error_context, get_file_contents, names, NO_DEFAULT
 from .utils.dicts import (
+    dict_to_toml,
     hash_statedict,
+    set_key_at_path,
     validate_dict,
     value_at_key_path,
     COLLECTION_OF_STRINGS,
@@ -369,13 +374,10 @@ class Node:
             validate_dict(attributes, NODE_ATTR_TYPES)
 
         self._add_host_keys = environ.get('BW_ADD_HOST_KEYS', False) == "1"
-        self._bundles = attributes.get('bundles', [])
-        self._compiling_metadata = Lock()
-        self._groups = set(attributes.get('groups', set()))
-        self._metadata_so_far = {}
-        self._node_metadata = attributes.get('metadata', {})
+        self._attributes = attributes
         self._ssh_conn_established = False
         self._ssh_first_conn_lock = Lock()
+        self.file_path = attributes.get('file_path')
         self.hostname = attributes.get('hostname', name)
         self.name = name
 
@@ -394,10 +396,10 @@ class Node:
             added_bundles = []
             found_bundles = []
             for group in self.groups:
-                for bundle_name in group.bundle_names:
+                for bundle_name in set(group._attributes.get('bundles', set())):
                     found_bundles.append(bundle_name)
 
-            for bundle_name in found_bundles + list(self._bundles):
+            for bundle_name in found_bundles + list(self._attributes.get('bundles', set())):
                 if bundle_name not in added_bundles:
                     added_bundles.append(bundle_name)
                     try:
@@ -441,14 +443,14 @@ class Node:
     def groups(self):
         _groups = set()
 
-        for group_name in self._groups:
+        for group_name in set(self._attributes.get('groups', set())):
             _groups.add(self.repo.get_group(group_name))
 
         for group in self.repo.groups:
             if group in _groups:
                 # we're already in this group, no need to check it again
                 continue
-            for pattern in group.member_patterns:
+            for pattern in group._member_patterns:
                 if pattern.search(self.name) is not None:
                     _groups.add(group)
 
@@ -742,6 +744,28 @@ class Node:
             wrapper_inner=self.cmd_wrapper_inner,
             wrapper_outer=self.cmd_wrapper_outer,
         )
+
+    @cached_property
+    def toml(self):
+        if not self.file_path or not self.file_path.endswith(".toml"):
+            raise ValueError(_("node {} not in TOML format").format(self.name))
+        return parse_toml(get_file_contents(self.file_path))
+
+    def toml_save(self):
+        try:
+            toml_doc = self.toml
+        except ValueError:
+            attributes = self._attributes.copy()
+            del attributes['file_path']
+            toml_doc = dict_to_toml(attributes)
+            self.file_path = join(self.repo.path, "nodes", self.name + ".toml")
+        with open(self.file_path, 'w') as f:
+            f.write(dump_toml(toml_doc))
+
+    def toml_set(self, path, value):
+        if not isinstance(path, tuple):
+            path = path.split("/")
+        set_key_at_path(self.toml, path, value)
 
     def upload(self, local_path, remote_path, mode=None, owner="", group="", may_fail=False):
         assert self.os in self.OS_FAMILY_UNIX

--- a/bundlewrap/utils/plot.py
+++ b/bundlewrap/utils/plot.py
@@ -136,7 +136,7 @@ def plot_group(groups, nodes, show_nodes):
         yield "\"{}\" [fontcolor=\"#303030\",shape=box,style=rounded];".format(node.name)
 
     for group in groups:
-        for subgroup in sorted(group.immediate_subgroup_names):
+        for subgroup in sorted(group._attributes.get('subgroups', set())):
             yield "\"{}\" -> \"{}\" [color=\"#6BB753\",penwidth=2]".format(group.name, subgroup)
         for subgroup in sorted(group._subgroup_names_from_patterns):
             yield "\"{}\" -> \"{}\" [color=\"#6BB753\",penwidth=2]".format(group.name, subgroup)
@@ -148,7 +148,7 @@ def plot_group(groups, nodes, show_nodes):
                     yield "\"{}\" -> \"{}\" [color=\"#D18C57\",penwidth=2]".format(
                         group.name, node.name)
                 else:
-                    for pattern in sorted(group.member_patterns):
+                    for pattern in sorted(group._member_patterns):
                         if pattern.search(node.name) is not None:
                             yield "\"{}\" -> \"{}\" [color=\"#714D99\",penwidth=2]".format(
                                 group.name, node.name)
@@ -174,21 +174,21 @@ def plot_node_groups(node):
     yield "\"{}\" [fontcolor=\"#303030\",shape=box,style=rounded];".format(node.name)
 
     for group in sorted(node.groups):
-        for subgroup in sorted(group.immediate_subgroup_names):
+        for subgroup in sorted(group._attributes.get('subgroups', set())):
             if subgroup in names(node.groups):
                 yield "\"{}\" -> \"{}\" [color=\"#6BB753\",penwidth=2]".format(
                     group.name, subgroup)
-        for pattern in sorted(group.immediate_subgroup_patterns):
+        for pattern in sorted(group._immediate_subgroup_patterns):
             for group2 in sorted(node.groups):
                 if pattern.search(group2.name) is not None and group2 != group:
                     yield "\"{}\" -> \"{}\" [color=\"#6BB753\",penwidth=2]".format(
                         group.name, group2.name)
 
-        if group in node._groups:
+        if group in node._attributes.get('groups', set()):
             yield "\"{}\" -> \"{}\" [color=\"#D18C57\",penwidth=2]".format(
                 group.name, node.name)
         else:
-            for pattern in sorted(group.member_patterns):
+            for pattern in sorted(group._member_patterns):
                 if pattern.search(node.name) is not None:
                     yield "\"{}\" -> \"{}\" [color=\"#714D99\",penwidth=2]".format(
                         group.name, node.name)

--- a/bundlewrap/utils/text.py
+++ b/bundlewrap/utils/text.py
@@ -254,3 +254,27 @@ def parse_duration(duration):
         else:
             raise ValueError(_("{} is not a valid duration string").format(repr(duration)))
     return timedelta(days=days, seconds=seconds)
+
+
+def toml_clean(s):
+    """
+    Removes duplicate sections from TOML, e.g.:
+
+        [foo]     <--- this line will be removed since it's redundant
+        [foo.bar]
+        baz = 1
+    """
+    lines = list(s.splitlines())
+    result = []
+    previous = ""
+    for line in lines.copy():
+        print("line: " + line)
+        print("prev: " + previous)
+        if line.startswith("[") and line.endswith("]"):
+            if line[1:].startswith(previous + "."):
+                print("pop: " + result.pop())
+            previous = line[1:-1]
+        else:
+            previous = ""
+        result.append(line)
+    return "\n".join(result)

--- a/docs/content/guide/toml.md
+++ b/docs/content/guide/toml.md
@@ -1,0 +1,83 @@
+# TOML nodes and groups
+
+The primary way to define nodes is in [nodes.py](../repo/nodes.py.md). However, BundleWrap also provides a built-in alternative that you can use to define each node in a [TOML](https://github.com/toml-lang/toml) file. Doing this has pros and cons, which is why you can choose which way is best for you.
+
+*Pros*
+
+* One file per node
+* Node files are machine-readable and -writeable
+* Easier on the eyes for nodes with simple metadata
+
+*Cons*
+
+* Does not support [Fault objects](../api/#bundlewraputilsfault)
+* Does not support [atomic()](../repo/groups.py.md#metadata)
+* Does not support `None`
+* More difficult to read for long, deeply nested metadata
+
+<br>
+
+## Using TOML nodes
+
+First, you have to make sure your `nodes.py` doesn't overwrite your TOML nodes. Check if your `nodes.py` overwrites the `nodes` dict:
+
+    nodes = {  # bad
+        "my_node": {...},
+    }
+
+TOML nodes will be added to the `nodes.py` context automatically, so change your `nodes.py` to add to them (or just leave the file empty):
+
+    nodes["my_node"] = {  # good
+        ...
+    }
+
+Now you are all set to create your first TOML node. Create a file called `nodes/nodenamegoeshere.toml`:
+
+    hostname = "tomlnode.example.com"
+    bundles = [
+        "bundle1",
+        "bundle2",
+    ]
+
+    [metadata]
+    foo = "bar"
+
+    [metadata.baz]
+    frob = 47
+
+And that's it. This node will now be added to your other nodes. You may use subdirectories of `nodes/`, but the node name will always just be the filename minus the ".toml" extension.
+
+<br>
+
+## Converting existing nodes
+
+This is an easy one line operation:
+
+    bw debug -n nodenamegoeshere -c "node.toml_save()"
+
+Don't forget to remove the original node though.
+
+<br>
+
+## Editing TOML nodes from Python
+
+BundleWrap uses [tomlkit](https://github.com/sdispater/tomlkit) internally and exposes a `TOMLDocument` instance as `node.toml` for you to modify:
+
+    $ bw debug -n nodenamegoeshere
+    >>> node.file_path
+    nodes/nodenamegoeshere.toml
+    >>> node.toml['bundles'].append("bundle3")
+    >>> node.toml_save()
+
+For your convenience, `.toml_set()` is also provided to easily set nested dict values:
+
+    >>> node.toml_set("metadata/foo/bar/baz", 47)
+    >>> node.toml_save()
+
+This should make it pretty straightforward to make changes to lots of nodes without the headaches of using `sed` or something of that nature to edit Python code in `nodes.py`.
+
+<br>
+
+## TOML groups
+
+They work exactly the same way as nodes, but have their own `groups/` directory. `.toml`, `.toml_set()` and `toml_save()` are also found on `Group` objects.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -28,6 +28,8 @@ Should you already know your way around, just click on the part of your repo tha
 <a href="/repo/libs">libs/</a>
 <a href="/guide/secrets">.secrets.cfg</a>
 <a href="/repo/groups.py">groups.py</a>
+nodes/
+     <a href="/guide/toml">nodename.toml</a>
 <a href="/repo/nodes.py">nodes.py</a>
 <a href="/repo/plugins">plugins.json</a>
 <a href="/repo/requirements.txt">requirements.txt</a>

--- a/docs/content/repo/nodes.py.md
+++ b/docs/content/repo/nodes.py.md
@@ -52,6 +52,8 @@ Node files would then append `nodes`, like this:
 		'hostname': "node-1.example.com",
 	}
 
+Alternatively, consider using [TOML nodes](../guide/toml.md).
+
 <br>
 
 # Node attribute reference

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
   - Writing plugins: guide/dev_plugin.md
   - Python API: guide/api.md
   - OS compatibility: guide/os_compatibility.md
+  - TOML nodes and groups: guide/toml.md
   - Migrating to 2.0: guide/migrate_12.md
   - Migrating to 3.0: guide/migrate_23.md
 - Repository:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "passlib",
         "pyyaml",
         "requests >= 1.0.0",
+        "tomlkit",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
```$ bw debug -n pi-cabinet
BundleWrap 4.0.0 interactive repository inspector
> You can access the current repository as 'repo'.
> You can access the selected node as 'node'.
>>> node.file_path
'[...]/nodes.py'
>>> node.toml
[...]
ValueError: node pi-cabinet not in TOML format
>>> node.toml_save()
>>> node.file_path
'[...]/nodes/pi-cabinet.toml'
>>> node.toml
{'hostname': '[...]', 'bundles': ['led-cabinet', 'led-neopixel'], 'metadata': {'ubuntu_release': 'bionic', 'interfaces': {'eth0': {'dhcp': True, 'ip_addresses': ['192.168.36.3']}}, 'systemd': {'persistent_journal': False}}}
>>> node.toml_set("metadata/some/thing/nested", 47)
>>> node.toml_save()


$ cat nodes/pi-cabinet.toml
hostname = "[...]"
bundles = ["led-cabinet", "led-neopixel"]

[metadata]
ubuntu_release = "bionic"

[metadata.interfaces]
[metadata.interfaces.eth0]
dhcp = true
ip_addresses = ["192.168.36.3"]

[metadata.systemd]
persistent_journal = false

[metadata.some]
[metadata.some.thing]
nested = 47
```