### PR TITLE
Explicitly document metadata priority

### DIFF
--- a/docs/content/repo/groups.py.md
+++ b/docs/content/repo/groups.py.md
@@ -93,7 +93,7 @@ The NTP servers are appended: a node in both groups will have all three of them.
 
 <div class="alert alert-warning">BundleWrap will consider group hierarchy when merging metadata. For example, it is possible to define a default nameserver for the "eu" group and then override it for the "eu.frankfurt" subgroup. The catch is that this only works for groups that are connected through a subgroup hierarchy. Independent groups will have their metadata merged in an undefined order. <code>bw test</code> will report conflicting metadata in independent groups as a metadata collision.</div>
 
-<div class="alert alert-info">Also see the <a href="../nodes.py#metadata">documentation for node.metadata</a> for more information.</div>
+<div class="alert alert-info">Also see the <a href="../nodes.py#metadata">documentation for node.metadata</a> and <a href="../metadata.py#Priority">metadata.py</a> for more information.</div>
 
 <br>
 

--- a/docs/content/repo/metadata.py.md
+++ b/docs/content/repo/metadata.py.md
@@ -46,3 +46,21 @@ On the other hand, if your reactor only needs to provide new metadata in *some* 
 
 
 <div class="alert alert-info">For your convenience, you can access <code>repo</code>, <code>node</code>, <code>metadata_reactors</code>, and <code>DoNotRunAgain</code> in <code>metadata.py</code> without importing them.</div>
+
+
+## Priority
+
+For atomic ("primitive") data types like `int` or `bool`:
+
+1.  Nodes
+2.  Groups
+3.  Reactors
+4.  Defaults
+
+Node metadata wins over group metadata, groups win over reactors, reactors win over defaults.
+
+This also applies to type conflicts: For example, specifying a boolean flag in node metadata will win over a list returned by a metadata reactor. (You should probably avoid situations like this entirely.)
+
+Set-like data types will be merged recursively.
+
+<div class="alert alert-info">Also see the <a href="../nodes.py#metadata">documentation for node.metadata</a> and <a href="../groups.py#metadata">group.metadata</a> for more information.</div>

--- a/docs/content/repo/nodes.py.md
+++ b/docs/content/repo/nodes.py.md
@@ -119,7 +119,7 @@ You are restricted to using only the following types in metadata:
 * `None`
 * `bundlewrap.utils.Fault`
 
-<div class="alert alert-info">Also see the <a href="../groups.py#metadata">documentation for group.metadata</a> for more information.</div>
+<div class="alert alert-info">Also see the <a href="../groups.py#metadata">documentation for group.metadata</a> and <a href="../metadata.py#Priority">metadata.py</a> for more information.</div>
 
 <br>
 


### PR DESCRIPTION
This should be documented explicitly, since it's a bit confusing (reactors can react to static metadata, but they can't overwrite it, only maybe merge into it).