### PR TITLE
Metadata: Only report clashes if values are not equal

### DIFF
--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -108,21 +108,21 @@ def check_for_metadata_conflicts_between_defaults_and_reactors(node):
         for path in map_dict_keys(d):
             value = value_at_key_path(d, path)
             if isinstance(value, dict):
-                yield path, TYPE_DICT
+                yield path, value, TYPE_DICT
             elif isinstance(value, set):
-                yield path, TYPE_SET
+                yield path, value, TYPE_SET
             else:
-                yield path, TYPE_OTHER
+                yield path, value, TYPE_OTHER
 
     for prefix in ("metadata_defaults:", "metadata_reactor:"):
         paths = {}
         for identifier, layer in node._metadata_stack._layers.items():
             if identifier.startswith(prefix):
-                for path, current_type in paths_with_types(layer):
+                for path, value, current_type in paths_with_types(layer):
                     try:
-                        prev_type, prev_identifier = paths[path]
+                        prev_type, prev_identifier, prev_value = paths[path]
                     except KeyError:
-                        paths[path] = current_type, identifier
+                        paths[path] = current_type, identifier, value
                     else:
                         if (
                             prev_type == TYPE_DICT
@@ -134,7 +134,7 @@ def check_for_metadata_conflicts_between_defaults_and_reactors(node):
                             and current_type == TYPE_SET
                         ):
                             pass
-                        else:
+                        elif value != prev_value:
                             raise ValueError(_(
                                 "{a} and {b} are clashing over this key path: {path}"
                             ).format(


### PR DESCRIPTION
Makes it possible to return identicals 'defaults' from different bundles
or do more complicated stuff like this:

    @metadata_reactor
    def generic_default(metadata):
        # A generic default that works for most system. (Yes, this
        # particular case could be solved without a reactor. Think of a more
        # complicated example, where this function depends on other factors.)
        def_iface = list(metadata.get('interfaces').keys())[0]

        return {
            'internal_interface': metadata.get('internal_interface', def_iface),
        }

    @metadata_reactor
    def corner_case(metadata):
        # This is only present on some special systems.
        special_iface = 'eth2'

        if metadata.get(f'interfaces/{special_iface}', None) is not None:
            return {
                'internal_interface': special_iface,
            }
        else:
            return {}