### PR TITLE
Metastack: Only return early if this is the first value we see

### DIFF
--- a/bundlewrap/utils/metastack.py
+++ b/bundlewrap/utils/metastack.py
@@ -56,10 +56,11 @@ class Metastack:
                 except KeyError:
                     pass
                 else:
-                    if isinstance(value, UNMERGEABLE):
-                        return value
                     if undef:
-                        # First time we see anything.
+                        # First time we see anything. If we can't merge
+                        # it anyway, then return early.
+                        if isinstance(value, UNMERGEABLE):
+                            return value
                         result = {'data': value}
                         undef = False
                     else:


### PR DESCRIPTION
The old code returned UNMERGEABLE values if they showed up in lower
layers. See failed tests.