### PR TITLE
Add "JSON data" to text types

### DIFF
--- a/bundlewrap/utils/remote.py
+++ b/bundlewrap/utils/remote.py
@@ -75,6 +75,7 @@ class PathInfo:
             "text" in self.desc or
             self.desc in (
                 "empty",
+                "JSON data",
                 "OpenSSH ED25519 public key",
                 "OpenSSH RSA public key",
                 "OpenSSH DSA public key",


### PR DESCRIPTION
file(1) began classifying JSON files as "JSON data" in some recent
release.