### PR TITLE
Fault: Hash kwargs recursively

### DIFF
--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -113,7 +113,7 @@ class Fault:
 
         for key, value in sorted(kwargs.items()):
             self.id_list.append(hash(key))
-            self.id_list.append(value)
+            self.id_list.append(_recursive_hash(value))
 
         self._available = None
         self._exc = None
@@ -149,7 +149,7 @@ class Fault:
             return self.id_list == other.id_list
 
     def __hash__(self):
-        return _recursive_hash(self.id_list)
+        return hash(tuple(self.id_list))
 
     def __len__(self):
         return len(self.value)

--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -113,7 +113,7 @@ class Fault:
 
         for key, value in sorted(kwargs.items()):
             self.id_list.append(hash(key))
-            self.id_list.append(hash(value))
+            self.id_list.append(_recursive_hash(value))
 
         self._available = None
         self._exc = None
@@ -202,6 +202,25 @@ for method_name in (
     'zfill',
 ):
     setattr(Fault, method_name, _make_method_callback(method_name))
+
+
+def _recursive_hash(obj):
+    hashes = []
+    if isinstance(obj, list):
+        for i in obj:
+            hashes.append(_recursive_hash(i))
+        return hash(tuple(hashes))
+    elif isinstance(obj, set):
+        for i in sorted(obj):
+            hashes.append(_recursive_hash(i))
+        return hash(tuple(hashes))
+    elif isinstance(obj, dict):
+        for k, v in sorted(obj.items()):
+            hashes.append(hash(k))
+            hashes.append(_recursive_hash(v))
+        return hash(tuple(hashes))
+    else:
+        return hash(obj)
 
 
 def get_file_contents(path):

--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -113,7 +113,7 @@ class Fault:
 
         for key, value in sorted(kwargs.items()):
             self.id_list.append(hash(key))
-            self.id_list.append(_recursive_hash(value))
+            self.id_list.append(value)
 
         self._available = None
         self._exc = None
@@ -149,7 +149,7 @@ class Fault:
             return self.id_list == other.id_list
 
     def __hash__(self):
-        return hash(tuple(self.id_list))
+        return _recursive_hash(self.id_list)
 
     def __len__(self):
         return len(self.value)

--- a/tests/unit/faults.py
+++ b/tests/unit/faults.py
@@ -315,3 +315,20 @@ def test_eq_and_hash_do_not_resolve_fault():
     assert a == b
 
     s = {a, b}
+
+
+def test_kwargs_changed_after_creation():
+    def callback():
+        return 'foo'
+
+    data = {
+        'foo': 0,
+    }
+    a = Fault('id foo', callback, data=data)
+
+    data['foo'] = 1
+    b = Fault('id foo', callback, data=data)
+
+    # Both Faults reference the same dict, so they must be considered
+    # equal.
+    assert a == b

--- a/tests/unit/faults.py
+++ b/tests/unit/faults.py
@@ -249,6 +249,7 @@ def test_kwargs_add_to_idlist():
     a = Fault('id foo', callback, foo='bar', baz='bam', frob='glob')
     b = Fault('id foo', callback, different='kwargs')
     assert a != b
+    assert hash(a) != hash(b)
 
 
 def test_unhashable_dict_kwargs_add_to_idlist():
@@ -258,6 +259,7 @@ def test_unhashable_dict_kwargs_add_to_idlist():
     a = Fault('id foo', callback, foo='bar', baz={1: {2: {3: 4}}})
     b = Fault('id foo', callback, foo='bar', baz={1: {3: {3: 4}}})
     assert a != b
+    assert hash(a) != hash(b)
 
 
 def test_unhashable_list_kwargs_add_to_idlist():
@@ -267,6 +269,7 @@ def test_unhashable_list_kwargs_add_to_idlist():
     a = Fault('id foo', callback, foo='bar', baz=[1, 2, [3, 4]])
     b = Fault('id foo', callback, foo='bar', baz=[1, [3, 4], 2])
     assert a != b
+    assert hash(a) != hash(b)
 
 
 def test_unhashable_set_kwargs_add_to_idlist():
@@ -276,6 +279,7 @@ def test_unhashable_set_kwargs_add_to_idlist():
     a = Fault('id foo', callback, foo='bar', baz={1, 2, 3})
     b = Fault('id foo', callback, foo='bar', baz={1, 2, 4})
     assert a != b
+    assert hash(a) != hash(b)
 
 
 def test_unhashable_dict_kwargs_add_to_idlist_equal():
@@ -285,6 +289,7 @@ def test_unhashable_dict_kwargs_add_to_idlist_equal():
     a = Fault('id foo', callback, foo='bar', baz={1: {2: {3: 4, 5: 6}}})
     b = Fault('id foo', callback, foo='bar', baz={1: {2: {5: 6, 3: 4}}})
     assert a == b
+    assert hash(a) == hash(b)
 
 
 def test_unhashable_list_kwargs_add_to_idlist_equal():
@@ -301,9 +306,10 @@ def test_unhashable_set_kwargs_add_to_idlist_equal():
     def callback():
         return 'foo'
 
-    a = Fault('id foo', callback, foo='bar', baz=set([1, 2, 3]))
-    b = Fault('id foo', callback, foo='bar', baz=set([1, 3, 2]))
+    a = Fault('id foo', callback, foo='bar', baz={1, 2, 3})
+    b = Fault('id foo', callback, foo='bar', baz={1, 3, 2})
     assert a == b
+    assert hash(a) == hash(b)
 
 
 def test_eq_and_hash_do_not_resolve_fault():
@@ -329,6 +335,38 @@ def test_kwargs_changed_after_creation():
     data['foo'] = 1
     b = Fault('id foo', callback, data=data)
 
-    # Both Faults reference the same dict, so they must be considered
-    # equal.
+    # Even though both Faults reference the same dict, hashes are built
+    # on Fault creation based on the actual values in mutable
+    # parameters.
+    assert a != b
+    assert hash(a) != hash(b)
+
+
+def test_kwargs_not_changed_after_creation():
+    def callback():
+        return 'foo'
+
+    data = {
+        'foo': 0,
+    }
+    a = Fault('id foo', callback, data=data)
+    b = Fault('id foo', callback, data=data)
+
     assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_hash_does_not_change():
+    def callback():
+        return 'foo'
+
+    data = {
+        'foo': 0,
+    }
+    a = Fault('id foo', callback, data=data)
+    hash1 = hash(a)
+
+    data['foo'] = 1
+    hash2 = hash(a)
+
+    assert hash1 == hash2

--- a/tests/unit/faults.py
+++ b/tests/unit/faults.py
@@ -251,6 +251,61 @@ def test_kwargs_add_to_idlist():
     assert a != b
 
 
+def test_unhashable_dict_kwargs_add_to_idlist():
+    def callback():
+        return 'foo'
+
+    a = Fault('id foo', callback, foo='bar', baz={1: {2: {3: 4}}})
+    b = Fault('id foo', callback, foo='bar', baz={1: {3: {3: 4}}})
+    assert a != b
+
+
+def test_unhashable_list_kwargs_add_to_idlist():
+    def callback():
+        return 'foo'
+
+    a = Fault('id foo', callback, foo='bar', baz=[1, 2, [3, 4]])
+    b = Fault('id foo', callback, foo='bar', baz=[1, [3, 4], 2])
+    assert a != b
+
+
+def test_unhashable_set_kwargs_add_to_idlist():
+    def callback():
+        return 'foo'
+
+    a = Fault('id foo', callback, foo='bar', baz={1, 2, 3})
+    b = Fault('id foo', callback, foo='bar', baz={1, 2, 4})
+    assert a != b
+
+
+def test_unhashable_dict_kwargs_add_to_idlist_equal():
+    def callback():
+        return 'foo'
+
+    a = Fault('id foo', callback, foo='bar', baz={1: {2: {3: 4, 5: 6}}})
+    b = Fault('id foo', callback, foo='bar', baz={1: {2: {5: 6, 3: 4}}})
+    assert a == b
+
+
+def test_unhashable_list_kwargs_add_to_idlist_equal():
+    def callback():
+        return 'foo'
+
+    a = Fault('id foo', callback, foo='bar', baz=[1, 2, 3])
+    b = Fault('id foo', callback, foo='bar', baz=[1, 2, 3])
+    assert id(a) != id(b)
+    assert a == b
+
+
+def test_unhashable_set_kwargs_add_to_idlist_equal():
+    def callback():
+        return 'foo'
+
+    a = Fault('id foo', callback, foo='bar', baz=set([1, 2, 3]))
+    b = Fault('id foo', callback, foo='bar', baz=set([1, 3, 2]))
+    assert a == b
+
+
 def test_eq_and_hash_do_not_resolve_fault():
     def callback():
         raise Exception('Fault resolved, this should not happen')


### PR DESCRIPTION
Mutable objects are not hashable in Python. We'd like to pass those as
arguments to Faults, though. For example:

    def whatever(data):
        return json.dumps(data)

    f = Fault('foo', whatever, data={'what': 'ever', 'some': other_fault})

Mutable objects are not hashable, because, well, they're mutable. You
cannot determine a hash, because that object might change later
in-place.

Strictly speaking, this is a problem for us, too:

    def my_function(data):
        return f'{repr(data)}'

    dirty_dict = {
        'foo': 0,
    }
    f = Fault('whatever', my_function, data=dirty_dict)

    dirty_dict['foo'] = 1
    g = Fault('whatever', my_function, data=dirty_dict)

    print(f'Will print False: {f == g}')
    print(f'Will print same string twice, which is wrong: {str(f)}, {str(g)}')

Let's discuss whether we should do deepcopy kwargs or not.