### PR TITLE
git deploy cache

### DIFF
--- a/bundlewrap/items/git_deploy.py
+++ b/bundlewrap/items/git_deploy.py
@@ -1,10 +1,12 @@
 from atexit import register as at_exit
-from os import remove, setpgrp
+from hashlib import md5
+from os import getenv, getpid, makedirs, mkdir, remove, rmdir, setpgrp
 from os.path import isfile, join
 from shlex import quote
 from shutil import rmtree
 from subprocess import PIPE, Popen
-from tempfile import mkdtemp, NamedTemporaryFile
+from tempfile import gettempdir, NamedTemporaryFile
+from time import sleep
 
 from bundlewrap.exceptions import BundleError, RepositoryError
 from bundlewrap.items import Item
@@ -31,17 +33,81 @@ def is_ref(rev):
 def clone_to_dir(remote_url, rev):
     """
     Clones the given URL to a temporary directory, using a shallow clone
-    if the given revision is definitely not a commit hash.
+    if the given revision is definitely not a commit hash. Clones to
+    the base directory $BW_GIT_DEPLOY_CACHE if set.
 
-    Returns the path to the directory.
+    Returns the path to the repo directory and to another directory to
+    be deleted when the process exits (may be None).
     """
-    tmpdir = mkdtemp()
+    repo_dir_hashed = md5(remote_url.encode('UTF-8')).hexdigest()
+
+    cache_dir_env = getenv("BW_GIT_DEPLOY_CACHE")
+    if cache_dir_env:
+        # Do not remove this, because it was not created by us.
+        remove_dir = None
+        repo_dir = join(cache_dir_env, repo_dir_hashed)
+        lock_dir = join(cache_dir_env, repo_dir_hashed + ".bw_lock")
+    else:
+        remove_dir = join(gettempdir(), "bw-git-cache-{}".format(getpid()))
+        repo_dir = join(remove_dir, repo_dir_hashed)
+        lock_dir = join(remove_dir, repo_dir_hashed + ".bw_lock")
+
+    makedirs(repo_dir, exist_ok=True)
+
+    io.debug(_("{pid}: lock_dir {lock_dir}").format(lock_dir=lock_dir, pid=getpid()))
+    io.debug(_("{pid}: remove_dir {remove_dir}").format(remove_dir=remove_dir, pid=getpid()))
+    io.debug(_("{pid}: repo_dir {repo_dir}").format(repo_dir=repo_dir, pid=getpid()))
+
     if is_ref(rev) and not remote_url.startswith('http'):
         git_cmdline = ["clone", "--bare", "--depth", "1", "--no-single-branch", remote_url, "."]
     else:
         git_cmdline = ["clone", "--bare", remote_url, "."]
-    git_command(git_cmdline, tmpdir)
-    return tmpdir
+
+    # Use a lock directory to cooperate with other running instances
+    # of bw (in cases where $BW_GIT_DEPLOY_CACHE is used).
+    while True:
+        try:
+            mkdir(lock_dir)
+            io.debug(_("{pid}: Have lock on {lock_dir}").format(
+                lock_dir=lock_dir,
+                pid=getpid(),
+            ))
+            break
+        except FileExistsError:
+            io.debug(_("{pid}: Waiting for lock on {lock_dir} ...").format(
+                lock_dir=lock_dir,
+                pid=getpid(),
+            ))
+            sleep(1)
+
+    try:
+        # We now have a lock, but another process may have cloned
+        # the repo in the meantime. (It is vital to use a git command
+        # here, which does not traverse to parent directories.)
+        try:
+            git_command(
+                ["rev-parse", "--resolve-git-dir", "."],
+                repo_dir,
+                error_messages=False,
+            )
+            io.debug(_("{pid}: Repo already existed in {repo_dir}").format(
+                repo_dir=repo_dir,
+                pid=getpid(),
+            ))
+        except RuntimeError:
+            git_command(git_cmdline, repo_dir)
+            io.debug(_("{pid}: Cloned repo to {repo_dir}").format(
+                repo_dir=repo_dir,
+                pid=getpid(),
+            ))
+    finally:
+        rmdir(lock_dir)
+        io.debug(_("{pid}: Released lock on {lock_dir}").format(
+            lock_dir=lock_dir,
+            pid=getpid(),
+        ))
+
+    return repo_dir, remove_dir
 
 
 def get_local_repo_path(bw_repo_path, repo_name):
@@ -81,7 +147,7 @@ def get_local_repo_path(bw_repo_path, repo_name):
     ))
 
 
-def git_command(cmdline, repo_dir):
+def git_command(cmdline, repo_dir, error_messages=True):
     """
     Runs the given git command line in the given directory.
 
@@ -102,9 +168,11 @@ def git_command(cmdline, repo_dir):
     stdout, stderr = git_process.communicate()
     # FIXME integrate this into Item._command_results
     if git_process.returncode != 0:
-        io.stderr(_("failed command: {}").format(" ".join(cmdline)))
-        io.stderr(_("stdout:\n{}").format(stdout))
-        io.stderr(_("stderr:\n{}").format(stderr))
+        if error_messages:
+            io.stderr(_("{} failed command: {}").format(getpid(), " ".join(cmdline)))
+            io.stderr(_("{} failed in dir: {}").format(getpid(), repo_dir))
+            io.stderr(_("{} stdout:\n{}").format(getpid(), stdout))
+            io.stderr(_("{} stderr:\n{}").format(getpid(), stderr))
         raise RuntimeError(_("`git {command}` failed in {dir}").format(
             command=cmdline[1],
             dir=repo_dir,
@@ -144,9 +212,10 @@ class GitDeploy(Item):
     @cached_property
     def _repo_dir(self):
         if "://" in self.attributes['repo']:
-            repo_dir = clone_to_dir(self.attributes['repo'], self.attributes['rev'])
+            repo_dir, remove_dir = clone_to_dir(self.attributes['repo'], self.attributes['rev'])
             io.debug(_("registering {} for deletion on exit").format(repo_dir))
-            at_exit(rmtree, repo_dir)
+            if remove_dir is not None:
+                at_exit(rmtree, remove_dir, ignore_errors=True)
         else:
             repo_dir = get_local_repo_path(self.node.repo.path, self.attributes['repo'])
         return repo_dir

--- a/bundlewrap/items/git_deploy.py
+++ b/bundlewrap/items/git_deploy.py
@@ -213,8 +213,8 @@ class GitDeploy(Item):
     def _repo_dir(self):
         if "://" in self.attributes['repo']:
             repo_dir, remove_dir = clone_to_dir(self.attributes['repo'], self.attributes['rev'])
-            io.debug(_("registering {} for deletion on exit").format(repo_dir))
             if remove_dir is not None:
+                io.debug(_("registering {} for deletion on exit").format(remove_dir))
                 at_exit(rmtree, remove_dir, ignore_errors=True)
         else:
             repo_dir = get_local_repo_path(self.node.repo.path, self.attributes['repo'])

--- a/docs/content/guide/env.md
+++ b/docs/content/guide/env.md
@@ -22,6 +22,12 @@ Set this to an existing directory path to have BundleWrap write debug logs there
 
 <br>
 
+## `BW_GIT_DEPLOY_CACHE`
+
+Optional cache directory for <a href="../../items/git_deploy/#bw_git_deploy_cache">`git_deploy`</a> items.
+
+<br>
+
 ## `BW_HARDLOCK_EXPIRY`
 
 [Hard locks](locks.md) are automatically ignored after some time. By default, it's `"8h"`. You can use this variable to override that default.

--- a/docs/content/items/git_deploy.md
+++ b/docs/content/items/git_deploy.md
@@ -72,8 +72,8 @@ BundleWrap needs to store the deployed commit hash on the node. The `use_xattrs`
 
 This only affects repositories for which a URL has been specified.
 
-By default, BundleWrap will clone repos to a temporary directory. This is done once per BundleWrap process.
+With this env var unset, BundleWrap will clone repos to a temporary directory. This is done once per BundleWrap process and removed automatically when the process terminates.
 
 If you *manually* launch multiple parallel processes of `bw`, each of those will clone the git repo. This can create significant overhead, since they all create redundant copies. You can set `$BW_GIT_DEPLOY_CACHE` to an absolute path: All the `bw` processes will use it as a shared cache.
 
-Note: It is not wise to use this option on your workstation. BundleWrap will only ever clone repos, not pull them. This variable is meant as a temporary cache, for example in CI builds.
+Note: It is not wise to use this option on your workstation. BundleWrap will only ever clone repos, not pull or delete them. This variable is meant as a temporary cache, for example in CI builds, and you will have to clean it up yourself.

--- a/docs/content/items/git_deploy.md
+++ b/docs/content/items/git_deploy.md
@@ -68,12 +68,12 @@ BundleWrap needs to store the deployed commit hash on the node. The `use_xattrs`
 
 # Environment variables
 
-## `$BW_GIT_DEPLOY_CACHE`
+## `BW_GIT_DEPLOY_CACHE`
 
 This only affects repositories for which a URL has been specified.
 
 With this env var unset, BundleWrap will clone repos to a temporary directory. This is done once per BundleWrap process and removed automatically when the process terminates.
 
-If you *manually* launch multiple parallel processes of `bw`, each of those will clone the git repo. This can create significant overhead, since they all create redundant copies. You can set `$BW_GIT_DEPLOY_CACHE` to an absolute path: All the `bw` processes will use it as a shared cache.
+If you *manually* launch multiple parallel processes of `bw`, each of those will clone the git repo. This can create significant overhead, since they all create redundant copies. You can set `BW_GIT_DEPLOY_CACHE` to an absolute path: All the `bw` processes will use it as a shared cache.
 
 Note: It is not wise to use this option on your workstation. BundleWrap will only ever clone repos, not pull or delete them. This variable is meant as a temporary cache, for example in CI builds, and you will have to clean it up yourself.

--- a/docs/content/items/git_deploy.md
+++ b/docs/content/items/git_deploy.md
@@ -50,7 +50,7 @@ Alternatively, it can point directly to a git URL:
         },
     }
 
-Note however that this has a severe performance penalty, as a new clone of that repo has to be made every time the status of the item is checked.
+Note however that this has a performance penalty, as a new clone of that repo has to be made on every run of BundleWrap. (See section "Environment variables" below.)
 
 <br>
 
@@ -63,3 +63,17 @@ The `rev` attribute can contain anything `git rev-parse` can resolve into a comm
 ## use_xattrs
 
 BundleWrap needs to store the deployed commit hash on the node. The `use_xattrs` attribute controls how this is done. If set to `True`, the `attr` command on the node is used to store the hash as an extended file system attribute. Since `attr` might not be installed on the node, the default is to place a dotfile in the target directory instead (keep that in mind when deploying websites etc.).
+
+<br>
+
+# Environment variables
+
+## `$BW_GIT_DEPLOY_CACHE`
+
+This only affects repositories for which a URL has been specified.
+
+By default, BundleWrap will clone repos to a temporary directory. This is done once per BundleWrap process.
+
+If you *manually* launch multiple parallel processes of `bw`, each of those will clone the git repo. This can create significant overhead, since they all create redundant copies. You can set `$BW_GIT_DEPLOY_CACHE` to an absolute path: All the `bw` processes will use it as a shared cache.
+
+Note: It is not wise to use this option on your workstation. BundleWrap will only ever clone repos, not pull them. This variable is meant as a temporary cache, for example in CI builds.


### PR DESCRIPTION
Goals:

* Per-process cache: A single instance of `bw` (e.g., `bw test -d 3`) shall not clone repos over and over again.
* Shared cache (user opt-in): Multiple instances of `bw` shall be able to use a shared cache, if configured.
* Backwards-compatible. (I haven’t spent time on trying to improve the repo map.)