### PR TITLE
fix typo in docs

### DIFF
--- a/docs/content/guide/dev_item.md
+++ b/docs/content/guide/dev_item.md
@@ -84,9 +84,9 @@ Create a new file called `/your/bundlewrap/repo/items/foo.py`. You can use this 
             Do whatever is necessary to correct this item. The given ItemStatus
             object has the following useful information:
 
-                status.keys     list of cdict keys that need fixing
-                status.cdict    cached copy of self.cdict()
-                status.sdict    cached copy of self.sdict()
+                status.keys_to_fix  list of cdict keys that need fixing
+                status.cdict        cached copy of self.cdict()
+                status.sdict        cached copy of self.sdict()
             """
             raise NotImplementedError
 


### PR DESCRIPTION
The attribute of ItemStatus is called keys_to_fix instead of keys. This is fixed in the example item comment.