### PR TITLE
allow lock dir to be configured per node

### DIFF
--- a/bundlewrap/group.py
+++ b/bundlewrap/group.py
@@ -20,6 +20,7 @@ from .utils.text import mark_for_translation as _, toml_clean, validate_name
 GROUP_ATTR_DEFAULTS = {
     'cmd_wrapper_inner': "export LANG=C; {}",
     'cmd_wrapper_outer': "sudo sh -c {}",
+    'lock_dir': "/var/lib/bundlewrap",
     'dummy': False,
     'kubectl_context': None,
     'locking_node': None,
@@ -46,6 +47,7 @@ GROUP_ATTR_TYPES = {
     'bundles': COLLECTION_OF_STRINGS,
     'cmd_wrapper_inner': str,
     'cmd_wrapper_outer': str,
+    'lock_dir': str,
     'dummy': bool,
     'file_path': str,
     'kubectl_context': (str, type(None)),

--- a/docs/content/repo/nodes.py.md
+++ b/docs/content/repo/nodes.py.md
@@ -162,3 +162,11 @@ You will need to override this if the shell on your node sets environment variab
 <div class="alert alert-warning">Changing this setting will affect the security of the target system. Only do this for legacy systems that don't support shadow passwords.</div>
 
 This setting will affect how the [user item](../items/user.md) item operates. If set to `False`, password hashes will be written directly to `/etc/passwd` and thus be accessible to any user on the system. If the OS of the node is set to "openbsd", this setting has no effect as `master.shadow` is always used.
+
+<br>
+
+### lock_dir
+
+Directory that will be used for creating locks on the node. Defaults to `"/var/lib/bundlewrap"` Will be created if it does not exist.
+
+You will need to override this if `/var/lib` is restricted somehow on your node (SElinux, mounted readonly, etc.).


### PR DESCRIPTION
Add the `lock_dir` property that dictates where locks are stored on a
specific node. The peviously hardcoded `/var/lib/bundlewrap` is used as
a default. With this change, bundlewrap can be used on nodes, where
/var/lib is not acessable for some reason (e.g. mounted readonly).

This change also allows for usage on nodes without root access (#542)

I tested this manually using bw lock and bw apply. If you want an automated test, let me know!

Also I'm unsure if this change qualifies as IP.