### PR TITLE
items/pkg_pip: allow configuring pip_command

### DIFF
--- a/bundlewrap/group.py
+++ b/bundlewrap/group.py
@@ -40,6 +40,10 @@ GROUP_ATTR_DEFAULTS = {
     # soon as it appears in the repo - which is probably not what
     # people want.
     'os_version': (0,),
+    # On some nodes, we maybe have pip2 and pip3 installed, but there's
+    # no way of knowing which one the user wants. Or maybe there's only
+    # one of them, but there's no symlink to pip, only pip3.
+    'pip_command': 'pip',
     'use_shadow_passwords': True,
 }
 
@@ -57,6 +61,7 @@ GROUP_ATTR_TYPES = {
     'metadata': dict,
     'os': str,
     'os_version': TUPLE_OF_INTS,
+    'pip_command': str,
     'subgroups': COLLECTION_OF_STRINGS,
     'subgroup_patterns': COLLECTION_OF_STRINGS,
     'use_shadow_passwords': bool,

--- a/bundlewrap/items/pkg_pip.py
+++ b/bundlewrap/items/pkg_pip.py
@@ -9,12 +9,12 @@ from bundlewrap.utils.text import mark_for_translation as _
 def pkg_install(node, pkgname, version=None):
     if version:
         pkgname = "{}=={}".format(pkgname, version)
-    pip_path, pkgname = split_path(pkgname)
+    pip_path, pkgname = split_path(node, pkgname)
     return node.run("{} install -U {}".format(quote(pip_path), quote(pkgname)), may_fail=True)
 
 
 def pkg_installed(node, pkgname):
-    pip_path, pkgname = split_path(pkgname)
+    pip_path, pkgname = split_path(node, pkgname)
     result = node.run(
         "{} freeze | grep -i '^{}=='".format(quote(pip_path), pkgname),
         may_fail=True,
@@ -26,7 +26,7 @@ def pkg_installed(node, pkgname):
 
 
 def pkg_remove(node, pkgname):
-    pip_path, pkgname = split_path(pkgname)
+    pip_path, pkgname = split_path(node, pkgname)
     return node.run("{} uninstall -y {}".format(quote(pip_path), quote(pkgname)), may_fail=True)
 
 
@@ -104,7 +104,7 @@ class PipPkg(Item):
             ))
 
 
-def split_path(pkgname):
+def split_path(node, pkgname):
     virtualenv, pkgname = split(pkgname)
-    pip_path = join(virtualenv, "bin", "pip") if virtualenv else "pip"
+    pip_path = join(virtualenv, "bin", node.pip_command) if virtualenv else node.pip_command
     return pip_path, pkgname

--- a/docs/content/repo/nodes.py.md
+++ b/docs/content/repo/nodes.py.md
@@ -165,6 +165,14 @@ You will need to override this if `/var/lib` is restricted somehow on your node 
 
 <br>
 
+### pip_command
+
+This setting will affect how [pkg_pip](../items/pkg_pip.md) will behave. By default, it will use whatever `pip` on your system defaults to.
+
+You will need to override this if you don't have `pip`, but (for example) only `pip3`. Be aware that setting this to a full path will break the virtualenv functionality of `pkg_pip`
+
+<br>
+
 ### use_shadow_passwords
 
 <div class="alert alert-warning">Changing this setting will affect the security of the target system. Only do this for legacy systems that don't support shadow passwords.</div>


### PR DESCRIPTION
This allows to customize the call to `pip` in `pkg_pip:` items to fix the issue discussed in #524.

I thought about changing the default to pip3, but that may break existing repos, so i've decided against that.