### PR TITLE
items: Add stages

### DIFF
--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -24,6 +24,7 @@ BUILTIN_ITEM_ATTRIBUTES = {
     'needs': [],
     'preceded_by': [],
     'precedes': [],
+    'stage': 0,
     'error_on_missing_fault': False,
     'tags': [],
     'triggered': False,


### PR DESCRIPTION
Item's can have a "stage" property. All items on one specific stage
depdend on all items of all previous stages. Stages are integers with
the default stage being zero.

Example usecases are important initialization steps (that would have a
negative stage) and integration testing steps (that would have a
positive stage).

Fixes: #540

TODOs:
 - [x] Check with @fkusei if this suits their needs
 - [ ] Check with @trehn if the general concept is ok for bundlewrap
 - [ ] Add documentation
 - [ ] Add tests
 - [ ] Handle in `bw plot node` somehow (maybe color codes, boxes like bundles or at least allow hiding all those depndencies
 - [ ] (optional) Maybe create the following dependencies to generate nicer plots: `<items of stage 0> --> stage0post --> stage1pre --> <items of stage 1> --> stage1post --> stage2pre --> <items of stage 2>` instead of `<items of stage 0> --> stage0 --> <items of stage 1> --> <stage 1> --> <items of stage 2> --> <stage 2>`
 - [ ] fix skipping dependencies