### PR TITLE
hooks: call apply_start before parsing items

### DIFF
--- a/bundlewrap/cmdline/apply.py
+++ b/bundlewrap/cmdline/apply.py
@@ -28,8 +28,6 @@ def bw_apply(repo, args):
     target_nodes = get_target_nodes(repo, args['targets'])
     pending_nodes = target_nodes.copy()
 
-    io.progress_set_total(count_items(pending_nodes))
-
     try:
         repo.hooks.apply_start(
             repo,
@@ -43,6 +41,8 @@ def bw_apply(repo, args):
             x=red("!!!"),
         ))
         exit(1)
+
+    io.progress_set_total(count_items(pending_nodes))
 
     start_time = datetime.now()
     results = []


### PR DESCRIPTION
When setting the progress total by using count_items() before calling
the `apply_start` hook, all bundles and items will be parsed. That might
be undesirable if a hook should make changes to the local state that
would reflect in an item's state. Therefore we should set the progress
after calling the apply_start hook.

This change is backwards compatible because if a hook actually acesses
some of the bundles/items in the repo, they will be dynamically parsed
on demand thanks to the use of @cached_property.