### PR TITLE
cmdline/{apply,run}: sort node list in stats table

### DIFF
--- a/bundlewrap/cmdline/apply.py
+++ b/bundlewrap/cmdline/apply.py
@@ -144,8 +144,9 @@ def stats_summary(results, totals, total_duration):
         _("time"),
     ], ROW_SEPARATOR]
 
+    node_rows = []
     for result in results:
-        rows.append([
+        node_rows.append([
             result.node_name,
             str(result.total),
             str(result.correct),
@@ -154,6 +155,8 @@ def stats_summary(results, totals, total_duration):
             red_unless_zero(result.failed),
             format_duration(result.duration),
         ])
+
+    rows += sorted(node_rows, key=lambda n: n[0])
 
     if len(results) > 1:
         rows.append(ROW_SEPARATOR)

--- a/bundlewrap/cmdline/run.py
+++ b/bundlewrap/cmdline/run.py
@@ -73,6 +73,7 @@ def stats_summary(results, include_stdout, include_stderr):
     if include_stderr:
         rows[0].append(bold(_("stderr")))
 
+    node_rows = []
     for node_name, result in sorted(results.items()):
         row = [node_name]
         if result is None:
@@ -83,7 +84,7 @@ def stats_summary(results, include_stdout, include_stderr):
         else:
             row.append(red(str(result.return_code)))
         row.append(format_duration(result.duration, msec=True))
-        rows.append(row)
+        node_rows.append(row)
         if include_stdout or include_stderr:
             stdout = result.stdout.decode('utf-8', errors='replace').strip().split("\n")
             stderr = result.stderr.decode('utf-8', errors='replace').strip().split("\n")
@@ -97,8 +98,10 @@ def stats_summary(results, include_stdout, include_stderr):
                     continuation_row.append(stdout_line)
                 if include_stderr:
                     continuation_row.append(stderr_line)
-                rows.append(continuation_row)
-            rows.append(ROW_SEPARATOR)
+                node_rows.append(continuation_row)
+            node_rows.append(ROW_SEPARATOR)
+
+    rows += sorted(node_rows, key=lambda n: n[0])
 
     if include_stdout or include_stderr:
         # remove last ROW_SEPARATOR


### PR DESCRIPTION
This will sort the node list in the stats table. I think this is much more useful than the current "random" order (which seems to be the order in which the nodes finished processing?).