### PR TITLE
utils/Fault: support using {fault} in format_into()

### DIFF
--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -179,6 +179,8 @@ class Fault:
 
     def format_into(self, format_string):
         def callback():
+            if '{fault}' in format_string:
+                return format_string.format(fault=self.value)
             return format_string.format(self.value)
         return Fault(self.id_list + ['format_into ' + format_string], callback)
 


### PR DESCRIPTION
This allows people to use the fault in multiple positions in the format string.

I needed this to be able to generate a unique, but rotates-with-secret-rotation identifier, which will be used as name for dkim signing keys.

This is the code i've written: https://git.kunsmann.eu/kunsi/bundlewrap/commit/f6d6fd79587406852e6d992321befaf2fcf2d2f7