### PR TITLE
Pipe to 'less' if there are too many lines

### DIFF
--- a/bundlewrap/utils/ui.py
+++ b/bundlewrap/utils/ui.py
@@ -107,7 +107,12 @@ def page_lines(lines):
     """
     lines = list(lines)
     line_width = max([len(ansi_clean(line)) for line in lines])
-    if TTY and line_width > get_terminal_size().columns:
+    if (
+        TTY and (
+            line_width > get_terminal_size().columns or
+            len(lines) > get_terminal_size().lines
+        )
+    ):
         write_to_stream(STDOUT_WRITER, SHOW_CURSOR)
         env = environ.copy()
         env["LESS"] = env.get("LESS", "") + " -R"


### PR DESCRIPTION
1000 short lines still call for running a pager.

Either this, or *always* pipe to `less` and ask users to set `-F` in their `$LESS` if they want the `--quit-if-one-screen` behaviour. The latter is what I originally meant in #551, but it’s probably not going to happen, since BSD’s `less` is so broken.