### PR TITLE
bundlewrap.utils.Fault: add .as_htpasswd_entry()

### DIFF
--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -5,12 +5,12 @@ import hashlib
 from inspect import isgenerator
 from os import chmod, close, makedirs, remove
 from os.path import dirname, exists
-from passlib.hash import apr_md5_crypt
 from random import shuffle
 import stat
 from sys import stderr, stdout
 from tempfile import mkstemp
 
+from passlib.hash import apr_md5_crypt
 from requests import get
 
 from ..exceptions import DontCache, FaultUnavailable

--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -5,6 +5,7 @@ import hashlib
 from inspect import isgenerator
 from os import chmod, close, makedirs, remove
 from os.path import dirname, exists
+from passlib.hash import apr_md5_crypt
 from random import shuffle
 import stat
 from sys import stderr, stdout
@@ -181,6 +182,17 @@ class Fault:
         def callback():
             return format_string.format(self.value)
         return Fault(self.id_list + ['format_into ' + format_string], callback)
+
+    def as_htpasswd_entry(self, username):
+        def callback():
+            return '{}:{}'.format(
+                username,
+                apr_md5_crypt.encrypt(
+                    self.value,
+                    salt=hashlib.sha512(self.id_list[0].encode('utf-8')).hexdigest()[:8],
+                ),
+            )
+        return Fault(self.id_list + ['as_htpasswd_entry ' + username], callback)
 
     @property
     def is_available(self):

--- a/docs/content/guide/api.md
+++ b/docs/content/guide/api.md
@@ -250,5 +250,7 @@ Faults also support some rudimentary string operations such as appending a strin
 	'Password: VOd5PC'
 	>>> repo.vault.password_for("1").b64encode().value
 	'Vk9kNVA='
+	>>> repo.vault.password_for("1").as_htpasswd_entry("username").value
+	'username:$apr1$8be694c7…'
 
 These string methods are supported on Faults: `format`, `lower`, `lstrip`, `replace`, `rstrip`, `strip`, `upper`, `zfill`


### PR DESCRIPTION
This will allow users to easily generate htpasswd-compatible `username:password` lines. Similar functionality is already present in trehn/bundlewrap-teamvault for teamvault entries.

This pull request will fix #578 