### PR TITLE
FreeBSDPkg: Initial implemenation

### DIFF
--- a/bundlewrap/items/pkg_freebsd.py
+++ b/bundlewrap/items/pkg_freebsd.py
@@ -1,0 +1,90 @@
+from shlex import quote
+
+from bundlewrap.exceptions import BundleError
+from bundlewrap.items import Item
+from bundlewrap.utils.text import mark_for_translation as _
+
+def parse_pkg_name(pkgname, line):
+    # Contains the assumption that version may not contain '-', which is covered
+    # according to the FreeBSD docs (Section 5.2.4, "PKGNAMEPREFIX and PKGNAMESUFFIX")
+    installed_package, _, installed_version = line.rpartition('-')
+    assert installed_package != "", _("Unexpected FreeBSD package name: {line}").format(line=line)
+    return installed_package == pkgname, installed_version
+
+
+def pkg_install(node, pkgname, version):
+    # Setting version to None means "don't specify version".
+    if version is None:
+        full_name = pkgname
+    else:
+        full_name = pkgname + "-" + version
+
+    return node.run("pkg install -y {}".format(full_name), may_fail=True)
+
+
+def pkg_installed(node, pkgname):
+    result = node.run(
+        "pkg info | cut -f 1 -d ' '",
+        may_fail=True,
+    )
+    for line in result.stdout.decode('utf-8').strip().splitlines():
+        found, installed_version = parse_pkg_name(pkgname, line)
+        if found:
+            return installed_version
+
+    return False
+
+
+def pkg_remove(node, pkgname):
+    return node.run("pkg delete -y -R {}".format(quote(pkgname)), may_fail=True)
+
+
+class FreeBSDPkg(Item):
+    """
+    A package installed via pkg install/pkg delete.
+    """
+    BUNDLE_ATTRIBUTE_NAME = "pkg_freebsd"
+    ITEM_ATTRIBUTES = {
+        'installed': True,
+        'version': None,
+    }
+    ITEM_TYPE_NAME = "pkg_freebsd"
+
+    def __repr__(self):
+        return "<FreeBSDPkg name:{} installed:{}>".format(
+            self.name,
+            self.attributes['installed'],
+        )
+
+    def cdict(self):
+        cdict = self.attributes.copy()
+        if cdict['version'] is None or not cdict['installed']:
+            del cdict['version']
+        return cdict
+
+    def fix(self, status):
+        if self.attributes['installed'] is False:
+            pkg_remove(self.node, self.name)
+        else:
+            pkg_install(
+                self.node,
+                self.name,
+                self.attributes['version']
+            )
+
+    def sdict(self):
+        version = pkg_installed(self.node, self.name)
+        return {
+            'installed': bool(version),
+            'version': version if version else _("none"),
+        }
+
+    @classmethod
+    def validate_attributes(cls, bundle, item_id, attributes):
+        if not isinstance(attributes.get('installed', True), bool):
+            raise BundleError(_(
+                "expected boolean for 'installed' on {item} in bundle '{bundle}'"
+            ).format(
+                bundle=bundle.name,
+                item=item_id,
+            ))

--- a/bundlewrap/items/pkg_freebsd.py
+++ b/bundlewrap/items/pkg_freebsd.py
@@ -4,11 +4,13 @@ from bundlewrap.exceptions import BundleError
 from bundlewrap.items import Item
 from bundlewrap.utils.text import mark_for_translation as _
 
+
 def parse_pkg_name(pkgname, line):
     # Contains the assumption that version may not contain '-', which is covered
     # according to the FreeBSD docs (Section 5.2.4, "PKGNAMEPREFIX and PKGNAMESUFFIX")
-    installed_package, _, installed_version = line.rpartition('-')
-    assert installed_package != "", _("Unexpected FreeBSD package name: {line}").format(line=line)
+    installed_package, _sep, installed_version = line.rpartition('-')
+    assert installed_package != "", _(
+        "Unexpected FreeBSD package name: {line}").format(line=line)
     return installed_package == pkgname, installed_version
 
 

--- a/docs/content/items/pkg_freebsd.md
+++ b/docs/content/items/pkg_freebsd.md
@@ -1,0 +1,37 @@
+# FreeBSD package items
+
+Handles packages installed by `pkg` on FreeBSD systems.
+
+    pkg_freebsd = {
+        "foo": {
+            "installed": True,  # default
+        },
+        "bar": {
+            "installed": True,
+            "version": "1.0",
+        },
+        "baz": {
+            "installed": False,
+        },
+    }
+
+<br><br>
+
+# Attribute reference
+
+See also: [The list of generic builtin item attributes](../repo/items.py.md#builtin-item-attributes)
+
+<hr>
+
+## installed
+
+`True` when the package is expected to be present on the system; `False` if it should be purged.
+
+<hr>
+
+
+## version
+
+Optional version string. Can be used to select one specific version of a package.
+
+Ignored when `installed` is `False`.

--- a/docs/content/repo/items.py.md
+++ b/docs/content/repo/items.py.md
@@ -53,6 +53,7 @@ This table lists all item types included in BundleWrap along with the bundle att
 <tr><td><a href="../../items/postgres_db">postgres_db</a></td><td><code>postgres_dbs</code></td><td>Manages Postgres databases</td></tr>
 <tr><td><a href="../../items/postgres_role">postgres_role</a></td><td><code>postgres_roles</code></td><td>Manages Postgres roles</td></tr>
 <tr><td><a href="../../items/pkg_pip">pkg_pip</a></td><td><code>pkg_pip</code></td><td>Installs and removes Python packages with pip</td></tr>
+<tr><td><a href="../../items/pkg_freebsd">pkg_freebsd</a></td><td><code>pkg_freebsd</code></td><td>Installs and removes FreeBSD packages with pkg</td></tr>
 <tr><td><a href="../../items/pkg_openbsd">pkg_openbsd</a></td><td><code>pkg_openbsd</code></td><td>Installs and removes OpenBSD packages with pkg_add/pkg_delete</td></tr>
 <tr><td><a href="../../items/svc_openbsd">svc_openbsd</a></td><td><code>svc_openbsd</code></td><td>Starts and stops services with OpenBSD's rc</td></tr>
 <tr><td><a href="../../items/svc_systemd">svc_systemd</a></td><td><code>svc_systemd</code></td><td>Starts and stops services with systemd</td></tr>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - k8s_*: items/k8s.md
   - pkg_apt: items/pkg_apt.md
   - pkg_dnf: items/pkg_dnf.md
+  - pkg_freebsd: items/pkg_freebsd.md
   - pkg_openbsd: items/pkg_openbsd.md
   - pkg_opkg: items/pkg_opkg.md
   - pkg_pacman: items/pkg_pacman.md

--- a/tests/unit/pkg_freebsd.py
+++ b/tests/unit/pkg_freebsd.py
@@ -1,19 +1,24 @@
 from bundlewrap.items.pkg_freebsd import parse_pkg_name
 from pytest import raises
 
+
 def test_not_found():
     found, version = parse_pkg_name("tree", "zsh-5.8")
     assert found is False
+
 
 def test_version():
     found, version = parse_pkg_name("tree", "tree-1.8.0")
     assert found is True
     assert version == "1.8.0"
 
+
 def test_version_with_epoch():
-    found, version = parse_pkg_name("zsh-syntax-highlighting", "zsh-syntax-highlighting-0.7.1,1")
+    found, version = parse_pkg_name(
+        "zsh-syntax-highlighting", "zsh-syntax-highlighting-0.7.1,1")
     assert found is True
     assert version == "0.7.1,1"
+
 
 def test_illegal_no_version():
     with raises(AssertionError):

--- a/tests/unit/pkg_freebsd.py
+++ b/tests/unit/pkg_freebsd.py
@@ -1,0 +1,20 @@
+from bundlewrap.items.pkg_freebsd import parse_pkg_name
+from pytest import raises
+
+def test_not_found():
+    found, version = parse_pkg_name("tree", "zsh-5.8")
+    assert found is False
+
+def test_version():
+    found, version = parse_pkg_name("tree", "tree-1.8.0")
+    assert found is True
+    assert version == "1.8.0"
+
+def test_version_with_epoch():
+    found, version = parse_pkg_name("zsh-syntax-highlighting", "zsh-syntax-highlighting-0.7.1,1")
+    assert found is True
+    assert version == "0.7.1,1"
+
+def test_illegal_no_version():
+    with raises(AssertionError):
+        parse_pkg_name("tree", "tree")


### PR DESCRIPTION
Manages packages via `pkg` on FreeBSD installations. Basically a copy of pkg_openbsd which I adapted to FreeBSD.

I tested it with a spare FreeBSD machine, should work as advertised.

I'm not particularly into Python and/or bundlewrap, so code style comments etc. are much appreciated :-)