### PR TITLE
Display newly created files

### DIFF
--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -532,7 +532,12 @@ class Item:
                 )):
                     self.fix(status_before)
             else:
-                if status_before.must_be_created:
+                # In order to display new files which are created we have to
+                # ignore the default `must_be_created` behaviour for files.
+                #
+                # See https://github.com/bundlewrap/bundlewrap/pull/587 for
+                # more information.
+                if status_before.must_be_created and self.ITEM_TYPE_NAME != 'file':
                     question_text = _("Doesn't exist. Will be created.")
                 elif status_before.must_be_deleted:
                     question_text = _("Found on node. Will be removed.")

--- a/bundlewrap/items/files.py
+++ b/bundlewrap/items/files.py
@@ -341,7 +341,7 @@ class File(Item):
             }
 
     def display_dicts(self, cdict, sdict, keys):
-        if sdict is None:  # The target file does not exist
+        if sdict is None and not self.attributes.get('delete', False):
             if (
                 self.attributes['content_type'] not in ('base64', 'binary') and
                 len(self.content) < DIFF_MAX_FILE_SIZE


### PR DESCRIPTION
Leverage the existing functionality to display a file diff on newly
created files. User, group and mode of the created file is displayed as
well.

This would fix #410.

Special-casing `file` in `Item/apply` is _really_ ugly, what do the maintainers think? I completely understand if you consider this unmergeable. In that case: how can we improve this? I'm not knowledgeable enough (just started using bundlewrap) to know more about the implementation.

Example output:

```
? test  ╭─ file:/etc/ssh/sshd_config
? test  │
? test  │  owner   → root
? test  │
? test  │  group   → root
? test  │
? test  │  mode   → 0644
? test  │
? test  │  content
? test  │  @@ -0,0 +1,29 @@
? test  │  +# This is the sshd server system-wide configuration file.  See
? test  │  +# sshd_config(5) for more information.
? test  │  +
? test  │  +# The configuration below was generated according to Mozilla's modern OpenSSH
? test  │  +# config: https://infosec.mozilla.org/guidelines/openssh.html
? test  │  +
? test  │  +# Listed in order of preference
? test  │  +HostKey /etc/ssh/ssh_host_ed25519_key
? test  │  +HostKey /etc/ssh/ssh_host_rsa_key
? test  │  +HostKey /etc/ssh/ssh_host_ecdsa_key
? test  │  +
? test  │  +# Only use secure Key Exchange/Encryption algorithms
? test  │  +KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
? test  │  +Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com
? test  │  +MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
? test  │  +
? test  │  +# Disable root login, disable password authentication
? test  │  +AuthenticationMethods publickey
? test  │  +PermitRootLogin no
? test  │  +
? test  │  +# Log key fingerprints of users
? test  │  +LogLevel VERBOSE
? test  │  +
? test  │  +# Log sftp level file access (read/write/etc.) that would not be easily logged otherwise.
? test  │  +Subsystem sftp  /usr/lib/ssh/sftp-server -f AUTHPRIV -l INFO
? test  │  +# End Mozilla recommendations
? test  │  +
? test  │  +# Allow client to pass locale environment variables
? test  │  +AcceptEnv LANG LC_*
? test  │
? test  ╰─ Fix file:/etc/ssh/sshd_config? [Y/n] n
```
