### PR TITLE
Add svc systemd masked attribute

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Torsten Rehn <torsten@rehn.email>
 Peter Hofmann <scm@uninformativ.de>
 Tim Buchwaldt <tim@buchwaldt.ws>
 Rico Ullmann <rico@erinnerungsfragmente.de>
+Christian Nicolai <chrnicolai@gmail.com>

--- a/docs/content/items/svc_systemd.md
+++ b/docs/content/items/svc_systemd.md
@@ -6,6 +6,7 @@ Handles services managed by systemd.
         "fcron.service": {
             "enabled": True,  # default
             "running": True,  # default
+            "masked": False,  # default
         },
         "sgopherd.socket": {
             "running": False,
@@ -29,6 +30,12 @@ See also: [The list of generic builtin item attributes](../repo/items.py.md#buil
 ## running
 
 `True` if the service is expected to be running on the system; `False` if it should be stopped. `None` makes BundleWrap ignore this setting.
+
+<hr>
+
+## masked
+
+`True` if the service is expected to be masked; `False` if it should be unmasked. `None` makes BundleWrap ignore this setting.
 
 <hr>
 


### PR DESCRIPTION
I want to propose adding the possibility to (un)mask systemd units via a new attribute `masked` (defaults to `False`) on `svc_systemd`. Inspired e.g. by Ansible [providing it as well](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/systemd_module.html#parameter-masked). I'd happy if you consider my contribution.

I manually tested this successfully on Debian 10 (Buster) where:
```
$ systemctl --version
systemd 241 (241)
+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid
```

I have to admit that I did not add a integration (or unit) test for this feature as I saw that no `svc_*` is tested.