### PR TITLE
bw repo create: Do not clobber existing repos

### DIFF
--- a/bundlewrap/repo.py
+++ b/bundlewrap/repo.py
@@ -271,6 +271,11 @@ class Repository(MetadataGenerator):
         Creates and returns a repository at path, which must exist and
         be empty.
         """
+        if listdir(path):
+            raise ValueError(_("'{}' is not an empty directory".format(
+                path
+            )))
+
         for filename, content in INITIAL_CONTENT.items():
             if callable(content):
                 content = content()


### PR DESCRIPTION
Do as the comment says and abort if the directory is not empty.

CC #530 

Note that both the old and the new code has a race condition. If two processes try to do this at the same time, weird things will happen. I can only see one clean solution to this: Stop requiring that the directory already exists. Then we can do an `mkdir()` and the one process where this succeeds wins and creates a consistent new repo. Same idea as with directory-based locks in the file system.

That race condition is probably pretty rare, though, and I’m not sure if fixing it is worth breaking the API.