### PR TITLE
Allow checking `action`s against multiple expected return codes

### DIFF
--- a/bundlewrap/items/actions.py
+++ b/bundlewrap/items/actions.py
@@ -186,9 +186,13 @@ class Action(Item):
                 may_fail=True,
             )
 
-        if self.attributes['expected_return_code'] is not None and \
-                not result.return_code == self.attributes['expected_return_code']:
-            raise ActionFailure(_("wrong return code: {}").format(result.return_code))
+        if self.attributes['expected_return_code'] is not None:
+            if isinstance(self.attributes['expected_return_code'], (list, set, tuple)):
+                if not result.return_code in self.attributes['expected_return_code']:
+                    raise ActionFailure(_("wrong return code: {}").format(result.return_code))
+            else:
+                if not result.return_code == self.attributes['expected_return_code']:
+                    raise ActionFailure(_("wrong return code: {}").format(result.return_code))
 
         if self.attributes['expected_stderr'] is not None and \
                 result.stderr_text != self.attributes['expected_stderr']:

--- a/docs/content/items/action.md
+++ b/docs/content/items/action.md
@@ -32,7 +32,7 @@ You can pipe data directly to the command running on the node. To do so, use thi
 
 ## expected_return_code
 
-Defaults to `0`. If the return code of your command is anything else, the action is considered failed. You can also set this to `None` and any return code will be accepted.
+Defaults to `0`. If the return code of your command is anything else, the action is considered failed. You can also specify a list, set or tuple and the action is considered failed if the command's return code is not contained in that enumeration. You can also set this to `None` and any return code will be accepted.
 
 <hr>
 

--- a/tests/integration/bw_apply_actions.py
+++ b/tests/integration/bw_apply_actions.py
@@ -99,3 +99,40 @@ def test_action_pipe_utf8(tmpdir):
         },
     )
     run("bw apply localhost", path=str(tmpdir))
+
+
+def test_action_return_codes(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'items': {
+                    'actions': {
+                        "single-code": {
+                            'command': "true",
+                            'expected_return_code': 0,
+                        },
+                        "multi-code-list": {
+                            'command': "false",
+                            'expected_return_code': [1],
+                        },
+                        "multi-code-tuple": {
+                            'command': "false",
+                            'expected_return_code': (1,),
+                        },
+                        "multi-code-set": {
+                            'command': "false",
+                            'expected_return_code': {1},
+                        }
+                    },
+                },
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+    run("bw apply localhost", path=str(tmpdir))


### PR DESCRIPTION
I propose allowing to pass in a list of integers to the `expected_return_code` attribute of an `action` in addition to passing in a single integer. The meaning here is that any of the listed integers signifies a successful execution of the action's `command`.

One use case I have is running `apt-get update` which may either exit with `0` (package lists got updated) or `100` (another process held the lock on the package lists) - in my setup I'd be fine with both as I just want to at least try to update the package lists once on a run. Currently I have to ignore the exit code alltogether on that aciton.

Maybe similiar use cases exist as well, where you want to allow certain exit codes without ignoring all of them.

I also added some tests for the `expected_return_code` attribute in general and my proposed addition of allowing lists in there. In case you like the direction of the PR but have concerns about the code quality or tests, please advise on desired changes :)