### PR TITLE
Add support for Alpine Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /dist/
 /docs/build/
+
+*.egg-info
+__pycache__/

--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Peter Hofmann <scm@uninformativ.de>
 Tim Buchwaldt <tim@buchwaldt.ws>
 Rico Ullmann <rico@erinnerungsfragmente.de>
 Christian Nicolai <chrnicolai@gmail.com>
+Galen Abell <galen@galenabell.com>

--- a/bundlewrap/items/pkg_apk.py
+++ b/bundlewrap/items/pkg_apk.py
@@ -1,0 +1,32 @@
+from shlex import quote
+
+from bundlewrap.items.pkg import Pkg
+
+
+class ApkPkg(Pkg):
+    """
+    A package installed by apk.
+    """
+
+    BUNDLE_ATTRIBUTE_NAME = "pkg_apk"
+    ITEM_TYPE_NAME = "pkg_apk"
+
+    @property
+    def quoted(self):
+        return quote(self.name)
+
+    def pkg_all_installed(self):
+        pkgs = self.run("apk list --installed").stdout.decode("utf-8")
+        for line in pkgs.splitlines():
+            pkg_name = line.split()[0]
+            yield f"{self.ITEM_TYPE_NAME}:{pkg_name}"
+
+    def pkg_install(self):
+        self.run(f"apk add {self.quoted}", may_fail=True)
+
+    def pkg_installed(self):
+        result = self.run(f"apk info --installed {self.quoted}", may_fail=True)
+        return result.return_code == 0 and self.quoted in result.stdout_text
+
+    def pkg_remove(self):
+        self.run(f"apk del {self.quoted}", may_fail=True)

--- a/bundlewrap/items/svc_openrc.py
+++ b/bundlewrap/items/svc_openrc.py
@@ -1,0 +1,105 @@
+from shlex import quote
+
+from bundlewrap.exceptions import BundleError
+from bundlewrap.items import Item
+from bundlewrap.utils.text import mark_for_translation as _
+
+
+def svc_start(node, svcname):
+    return node.run(f"rc-service {quote(svcname)} start", may_fail=True)
+
+
+def svc_running(node, svcname):
+    result = node.run(f"rc-service {quote(svcname)} status", may_fail=True)
+    return result.return_code == 0 and "started" in result.stdout_text
+
+
+def svc_stop(node, svcname):
+    return node.run(f"rc-service {quote(svcname)} stop", may_fail=True)
+
+
+def svc_enable(node, svcname):
+    return node.run(f"rc-update add {quote(svcname)}", may_fail=True)
+
+
+def svc_enabled(node, svcname):
+    result = node.run(
+        f"rc-update show default | grep -w {quote(svcname)}", may_fail=True
+    )
+    return result.return_code == 0 and svcname in result.stdout_text
+
+
+def svc_disable(node, svcname):
+    return node.run(f"rc-update del {quote(svcname)}", may_fail=True)
+
+
+class SvcOpenRC(Item):
+    """
+    A service managed by OpenRC init scripts.
+    """
+
+    BUNDLE_ATTRIBUTE_NAME = "svc_openrc"
+    ITEM_ATTRIBUTES = {
+        "running": True,
+        "enabled": True,
+    }
+    ITEM_TYPE_NAME = "svc_openrc"
+
+    def __repr__(self):
+        return "<SvcOpenRC name:{} enabled:{} running:{}>".format(
+            self.name, self.attributes["enabled"], self.attributes["running"],
+        )
+
+    def fix(self, status):
+        if "enabled" in status.keys_to_fix:
+            if self.attributes["enabled"]:
+                svc_enable(self.node, self.name)
+            else:
+                svc_disable(self.node, self.name)
+
+        if "running" in status.keys_to_fix:
+            if self.attributes["running"]:
+                svc_start(self.node, self.name)
+            else:
+                svc_stop(self.node, self.name)
+
+    def get_canned_actions(self):
+        return {
+            "stop": {
+                "command": f"rc-service {self.name} stop",
+                "needed_by": {self.id},
+            },
+            "restart": {
+                "command": f"rc-service {self.name} restart",
+                "needs": {self.id},
+            },
+            "reload": {
+                "command": f"rc-service {self.name} reload".format(self.name),
+                "needs": {
+                    # make sure we don't reload and restart simultaneously
+                    f"{self.id}:restart",
+                    # with only the dep on restart, we might still end
+                    # up reloading if the service itself is skipped
+                    # because the restart action has cascade_skip False
+                    self.id,
+                },
+            },
+        }
+
+    def sdict(self):
+        return {
+            "enabled": svc_enabled(self.node, self.name),
+            "running": svc_running(self.node, self.name),
+        }
+
+    @classmethod
+    def validate_attributes(cls, bundle, item_id, attributes):
+        for attribute in ("enabled", "running"):
+            if attributes.get(attribute, None) not in (True, False, None):
+                raise BundleError(
+                    _(
+                        "expected boolean or None for '{attribute}' on {item} in bundle '{bundle}'"
+                    ).format(
+                        attribute=attribute, bundle=bundle.name, item=item_id,
+                    )
+                )

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -468,6 +468,7 @@ class Node:
     )
 
     OS_FAMILY_LINUX = (
+        'alpine',
         'amazonlinux',
         'arch',
         'opensuse',

--- a/docs/content/items/pkg_apk.md
+++ b/docs/content/items/pkg_apk.md
@@ -1,0 +1,24 @@
+# apk package items
+
+Handles packages installed by `apk` on Alpine-based systems.
+
+    pkg_apk = {
+        "foopkg": {
+            "installed": True,  # default
+        },
+        "bar": {
+            "installed": False,
+        },
+    }
+
+<br><br>
+
+# Attribute reference
+
+See also: [The list of generic builtin item attributes](../repo/items.py.md#builtin-item-attributes)
+
+<hr>
+
+## installed
+
+`True` when the package is expected to be present on the system; `False` if it should be removed.

--- a/docs/content/items/svc_openrc.md
+++ b/docs/content/items/svc_openrc.md
@@ -1,0 +1,54 @@
+# openrc service items
+
+Handles services managed by openrc.
+
+    svc_openrc = {
+        "sshd": {
+            "enabled": True,  # default
+            "running": True,  # default
+        },
+        "nginx": {
+            "enabled": False,
+            "running": False,
+        },
+    }
+
+<br><br>
+
+# Attribute reference
+
+See also: [The list of generic builtin item attributes](../repo/items.py.md#builtin-item-attributes)
+
+<hr>
+
+## enabled
+
+`True` if the service shall be automatically started during system bootup; `False` otherwise. `None` makes BundleWrap ignore this setting.
+
+<hr>
+
+## running
+
+`True` if the service is expected to be running on the system; `False` if it should be stopped. `None` makes BundleWrap ignore this setting.
+
+<hr>
+
+## Canned actions
+
+See also: [Explanation of how canned actions work](../repo/items.py.md#canned-actions)
+
+## reload
+
+Reloads the service. Not all services support reloading.
+
+<hr>
+
+## restart
+
+Restarts the service.
+
+<hr>
+
+## stop
+
+Stops the service.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - git_deploy: items/git_deploy.md
   - group: items/group.md
   - k8s_*: items/k8s.md
+  - pkg_apk: items/pkg_apk.md
   - pkg_apt: items/pkg_apt.md
   - pkg_dnf: items/pkg_dnf.md
   - pkg_freebsd: items/pkg_freebsd.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - postgres_db: items/postgres_db.md
   - postgres_role: items/postgres_role.md
   - svc_openbsd: items/svc_openbsd.md
+  - svc_openrc: items/svc_openrc.md
   - svc_systemd: items/svc_systemd.md
   - svc_systemv: items/svc_systemv.md
   - svc_upstart: items/svc_upstart.md


### PR DESCRIPTION
This patchset implements Alpine Linux support to bundlewrap by adding two new items:
- `pkg_apk`: Item for interacting with Alpine's `apk` package manager. Currently supports installing and uninstalling packages.
- `svc_openrc`: Item for managing services using Alpine's default init system, `OpenRC`. Supports (re)starting, reloading, stopping, and enabling/disabling services.

I haven't written any tests since there doesn't seem to be a system in place for testing OS-specific features, but I'm happy to add those if anyone has a suggestion on how to do that.