### PR TITLE
Fix tests to use new repo branch name main

### DIFF
--- a/tests/integration/bw_apply_git_deploy.py
+++ b/tests/integration/bw_apply_git_deploy.py
@@ -12,7 +12,7 @@ def test_deploy_from_url(tmpdir):
                     'git_deploy': {
                         join(str(tmpdir), "git_deployed_bw"): {
                             'repo': "https://github.com/bundlewrap/bundlewrap.git",
-                            'rev': "master",
+                            'rev': "main",
                         },
                     },
                     'directories': {
@@ -45,7 +45,7 @@ def test_cannot_deploy_into_purged(tmpdir):
                     'git_deploy': {
                         join(str(tmpdir), "git_deployed_bw"): {
                             'repo': "https://github.com/bundlewrap/bundlewrap.git",
-                            'rev': "master",
+                            'rev': "main",
                         },
                     },
                     'directories': {


### PR DESCRIPTION
I saw that https://github.com/bundlewrap/bundlewrap was adjusted to use `main` branch instead of `master` in the last 1-2 days. As this branch name is relied on in tests of `git_deploy` item, they were failing. This simple PR proposes to fix this.