### PR TITLE
inherit tags for canned_actions

### DIFF
--- a/bundlewrap/deps.py
+++ b/bundlewrap/deps.py
@@ -154,7 +154,10 @@ def _inject_canned_actions(items):
     for item in items:
         for canned_action_name, canned_action_attrs in item.get_canned_actions().items():
             canned_action_id = f"{item.id}:{canned_action_name}"
-            canned_action_attrs.update({'triggered': True})
+            canned_action_attrs.update({
+                'triggered': True,
+                'tags': item.tags,
+            })
             action = Action(
                 item.bundle,
                 canned_action_id,


### PR DESCRIPTION
Thanks to canned action, it is very easy to create dependency errors
with code like this:

```
svc_systemd = {
    'test.service': {
        'tags': {'a'},
        'needed_by': {'!tag:a'},
    },
}
```

Therefore canned actions should inherit the tags of their parent
actions to avoid confisions by using the `!tag:foobar` selector.