### PR TITLE
Speedup CI by using SSH multiplexing on localhost

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,8 @@ jobs:
         cp ~/.ssh/id_ed25519.pub ~/.ssh/authorized_keys
         chmod og-rw ~
         ssh -o StrictHostKeyChecking=no localhost id
+        mkdir -p ~/.ssh/controlmasters
+        echo -e "Host localhost\n  ControlPath ~/.ssh/controlmasters/%C\n  ControlPersist 1h\n  ControlMaster auto" > ~/.ssh/config
     - name: Test with pytest
       run: |
         pytest tests


### PR DESCRIPTION
Reduces CI runtime on GHA from ~10minutes ([old run](https://github.com/bundlewrap/bundlewrap/actions/runs/580929111)) to ~3minutes, providing faster feedback and avoids wasting resources.

**Note:** this PR also adjusts the GHA workflow to use `main` branch name!