### PR TITLE
Remove redundant block_concurrent() from pkg_opkg, is already defined in Pkg

### DIFF
--- a/bundlewrap/items/pkg_opkg.py
+++ b/bundlewrap/items/pkg_opkg.py
@@ -10,10 +10,6 @@ class OpkgPkg(Pkg):
     BUNDLE_ATTRIBUTE_NAME = "pkg_opkg"
     ITEM_TYPE_NAME = "pkg_opkg"
 
-    @classmethod
-    def block_concurrent(cls, node_os, node_os_version):
-        return ["pkg_opkg"]
-
     def pkg_all_installed(self):
         result = self.run("opkg list-installed")
         for line in result.stdout.decode('utf-8').strip().split("\n"):


### PR DESCRIPTION
As `OpkgPkg` is derived from `Pkg` which already defines `block_concurrent()` in [a generic way](https://github.com/bundlewrap/bundlewrap/blob/main/bundlewrap/items/pkg.py#L18-L20), the re-definition with same functionality in `OpkgPkg` can be removed.