### PR TITLE
Don't rely on sudo to run postgres items

### DIFF
--- a/bundlewrap/group.py
+++ b/bundlewrap/group.py
@@ -19,7 +19,7 @@ from .utils.text import mark_for_translation as _, toml_clean, validate_name
 
 GROUP_ATTR_DEFAULTS = {
     'cmd_wrapper_inner': "export LANG=C; {}",
-    'cmd_wrapper_outer': "sudo sh -c {}",
+    'cmd_wrapper_outer': "sudo -u {1} sh -c {0}",
     'lock_dir': "/var/lib/bundlewrap",
     'dummy': False,
     'kubectl_context': None,

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -801,7 +801,7 @@ class Node:
         """
         return self.metadata
 
-    def run(self, command, data_stdin=None, may_fail=False, log_output=False):
+    def run(self, command, data_stdin=None, may_fail=False, log_output=False, user="root"):
         assert self.os in self.OS_FAMILY_UNIX
 
         if log_output:
@@ -844,6 +844,7 @@ class Node:
             username=self.username,
             wrapper_inner=self.cmd_wrapper_inner,
             wrapper_outer=self.cmd_wrapper_outer,
+            user=user,
         )
 
     @cached_property
@@ -890,8 +891,8 @@ class Node:
         self,
         autoskip_selector=(),
         autoonly_selector=(),
-        show_all=False, 
-        show_diff=True, 
+        show_all=False,
+        show_diff=True,
         workers=4,
     ):
         result = []
@@ -904,7 +905,7 @@ class Node:
                 self,
                 autoskip_selector=autoskip_selector,
                 autoonly_selector=autoonly_selector,
-                show_all=show_all, 
+                show_all=show_all,
                 show_diff=show_diff,
                 workers=workers,
             )

--- a/bundlewrap/operations.py
+++ b/bundlewrap/operations.py
@@ -205,10 +205,13 @@ def run(
     username=None,  # SSH auth
     wrapper_inner="{}",
     wrapper_outer="{}",
+    user="root",  # remote user running the command
 ):
     """
     Runs a command on a remote system.
     """
+    shell_command = wrapper_outer.format(quote(wrapper_inner.format(command)), user)
+
     ssh_command = [
         "ssh",
         "-o", "BatchMode=yes",
@@ -222,7 +225,7 @@ def run(
     if extra_args:
         ssh_command.extend(split(extra_args))
     ssh_command.append(hostname)
-    ssh_command.append(wrapper_outer.format(quote(wrapper_inner.format(command))))
+    ssh_command.append(shell_command)
 
     result = run_local(
         ssh_command,

--- a/docs/content/items/postgres_db.md
+++ b/docs/content/items/postgres_db.md
@@ -34,3 +34,9 @@ Name of the role which owns this database (defaults to `"postgres"`).
 By default, BundleWrap will only create a database using your default PostgreSQL template, which most likely is `template1`. This means it will use the same encoding and collation that `template1` uses. By specifying any of the attributes `encoding`, `collation`, or `ctype`, BundleWrap will instead create a new database from `template0`, thus allowing you to override said database attributes.
 
 These options are creation-time only.
+
+<hr>
+
+## delete
+
+`True` if the database should be deleted (defaults to `False`).

--- a/docs/content/items/postgres_role.md
+++ b/docs/content/items/postgres_role.md
@@ -34,3 +34,9 @@ Plaintext password to set for this role (will be hashed using MD5).
 ## password_hash
 
 As an alternative to `password`, this allows setting the raw hash as it will be stored in Postgres' internal database. Should start with "md5".
+
+<hr>
+
+## delete
+
+`True` if the role should be deleted (defaults to `False`).


### PR DESCRIPTION
This patch adds a new group/node attribute called `run_as_command`, which specifies the command that should be used to run commands as another user. This defaults to `sudo -u {user} {command}` but can easily be changed to allow other privilege escalators, for example: `doas -u {user} {command}`. This functionality is wrapped in a new Node method, `node.run_as(user, command, ...)`.

The postgres items have been updated to use the new `run_as` method, as well as using psql's `-c` argument rather than piping SQL directly into psql, as this makes it easier to run under the correct user.

Also updated the Postgres docs to include the `delete` attribute, which seems to be missing.

Fixes #612 