### PR TITLE
Add external password providers

### DIFF
--- a/bundlewrap/secrets.py
+++ b/bundlewrap/secrets.py
@@ -1,5 +1,4 @@
 from base64 import b64encode, urlsafe_b64decode
-from configparser import ConfigParser
 from functools import lru_cache
 import hashlib
 import hmac
@@ -27,7 +26,6 @@ HUMAN_CHARS_CONS = HUMAN_CHARS_START + ["bb", "bl", "cc", "ch", "ck", "dd", "dr"
                                         "ss", "st", "tl", "ts", "tt"]
 
 FILENAME_SECRETS = ".secrets.cfg"
-FILENAME_REPO_CONFIG = "repo.cfg"
 
 
 def choice_prng(lst, prng):
@@ -239,18 +237,8 @@ class SecretProxy:
         h.update(identifier.encode('utf-8'))
         return random(h.digest())
 
-    def _load_config(self, filename):
-        config = ConfigParser()
-        config_path = join(self.repo.path, filename)
-        try:
-            config.read(config_path)
-            return config
-        except IOError:
-            io.debug(_("unable to read {}").format(config_path))
-            raise
-
     def _load_keys(self):
-        config = self._load_config(FILENAME_SECRETS)
+        config = self.repo.secrets_config
 
         result = {}
         for section in config.sections():
@@ -258,7 +246,7 @@ class SecretProxy:
         return result
 
     def _get_password_provider(self, provider=None):
-        config = self._load_config(FILENAME_REPO_CONFIG)
+        config = self.repo.repo_config
 
         if not provider:
             provider = config['DEFAULT'].get('password_provider', None)

--- a/bundlewrap/secrets.py
+++ b/bundlewrap/secrets.py
@@ -261,7 +261,7 @@ class SecretProxy:
     def _load_password(self, identifier, provider=None, strip_whitespace=True):
         provider_cmd = self._get_password_provider(provider)
         if not provider_cmd:
-            raise FaultUnavailable(_(f'Password provider {provider} does not exist'))
+            raise FaultUnavailable(_(f'Password provider `{provider}` does not exist'))
 
         cmd = provider_cmd.format(quote(identifier))
         io.debug(f'calling password provider command for {identifier}: {cmd}')

--- a/bundlewrap/utils/testing.py
+++ b/bundlewrap/utils/testing.py
@@ -3,6 +3,7 @@ from subprocess import Popen, PIPE
 
 from ..bundle import FILENAME_BUNDLE, FILENAME_ITEMS
 from ..secrets import FILENAME_SECRETS
+from ..repo import FILENAME_REPO_CONFIG
 
 
 HOST_OS = {
@@ -54,6 +55,15 @@ def make_repo(tmpdir, bundles=None, groups=None, nodes=None):
         "Fl53iG1czBcaAPOKhSiJE7RjFU9nIAGkiKDy0k_LoTc=",
         "DbYiUu5VMfrdeSiKYiAH4rDOAUISipvLSBJI-T0SpeY=",
     ))
+
+    repo_config = tmpdir.join(FILENAME_REPO_CONFIG)
+    repo_config.write("""
+[DEFAULT]
+password_provider = echo
+
+[password_providers]
+echo = echo {}
+""")
 
 
 def run(command, path=None):

--- a/docs/content/guide/secrets.md
+++ b/docs/content/guide/secrets.md
@@ -70,6 +70,18 @@ database_password = "${repo.vault.decrypt("gAAAA[...]mrVMA==")}"
 
 <br>
 
+## External password providers
+
+BundleWrap can also inject passwords loaded from external password providers (for example, [pass](https://www.passwordstore.org/)). The external password provider should be a script that can be called with an identifier to return the password associated with that identifier. This can be accomplished by using the `password_from` vault method:
+
+<pre><code class="nohighlight">$ bw debug -c "print(repo.vault.password_from('my_password', provider='pass'))"
+very_secure_password
+</code></pre>
+
+The `provider` must be configured in the [repo.cfg](/repo/repo.cfg) configuration. If a provider name is not explicitly set, BundleWrap will try to use the default password provider. The `password_from` method will strip leading and trailing whitespace from the output of the provider by default; if this behavior is not desired, use the argument `strip_whitespace=False`.
+
+<br>
+
 ## Files
 
 You can also encrypt entire files:

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -27,6 +27,7 @@ Should you already know your way around, just click on the part of your repo tha
 <a href="/repo/hooks">hooks/</a>
 <a href="/guide/dev_item">items/</a>
 <a href="/repo/libs">libs/</a>
+<a href="/repo/repo.cfg">repo.cfg</a>
 <a href="/guide/secrets">.secrets.cfg</a>
 <a href="/repo/groups.py">groups.py</a>
 nodes/

--- a/docs/content/repo/layout.md
+++ b/docs/content/repo/layout.md
@@ -11,6 +11,10 @@ This page describes the various subdirectories and files than can exist inside a
 
 <table>
 <tr>
+<td><a href="/repo/repo.cfg">repo.cfg</a></td>
+<td>This file contains repository-wide configuration, for example external password providers.</td>
+</tr>
+<tr>
 <td><a href="/repo/nodes.py">nodes.py</a></td>
 <td>This file tells BundleWrap what nodes (servers, VMs, ...) there are in your environment and lets you configure options such as hostnames.</td>
 </tr>

--- a/docs/content/repo/repo.cfg.md
+++ b/docs/content/repo/repo.cfg.md
@@ -1,0 +1,38 @@
+# repo.cfg.md
+
+This file contains repository-wide configuration.
+
+Example:
+```cfg
+[DEFAULT]
+password_provider = pass
+
+[password_providers]
+pass = pass show {}
+```
+
+# Sections
+
+## DEFAULT
+
+This section allows you to define default values for certain options:
+
+- `password_provider`: The name of the default [external password provider](/guide/secrets/#external-password-providers) to use. See the [password_providers](#password_providers) section for more info.
+
+Example:
+```cfg
+[DEFAULT]
+password_provider = pass
+```
+
+## password_providers
+
+This section allows you to define external password providers that can be used instead of or in addition to the internal password generation. Each provider should have a name and a command, which will be interpolated with the identifier of the password to load.
+
+Example:
+```cfg
+[password_providers]
+pass = pass show {}
+```
+
+When a password is loaded from the `pass` provider, it will execute the following command: `pass show password_name`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
   - Migrating to 4.0: guide/migrate_34.md
 - Repository:
   - Overview: repo/layout.md
+  - repo.cfg: repo/repo.cfg.md
   - nodes.py: repo/nodes.py.md
   - groups.py: repo/groups.py.md
   - requirements.txt: repo/requirements.txt.md

--- a/tests/integration/secret.py
+++ b/tests/integration/secret.py
@@ -420,3 +420,31 @@ def test_faults_equality_random_bytes_as_base64(tmpdir):
     assert stdout == b"False\n"
     assert stderr == b""
     assert rcode == 0
+
+
+def test_faults_password_from(tmpdir):
+    make_repo(tmpdir)
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.password_from(\"test\"))'",
+        path=str(tmpdir),
+    )
+    assert stdout == b"test\n"
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.password_from(\"test\", provider=\"echo\"))'",
+        path=str(tmpdir),
+    )
+    assert stdout == b"test\n"
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw debug -c 'print(repo.vault.password_from(\"test\", provider=\"missing\"))'",
+        path=str(tmpdir),
+    )
+    assert stdout == b""
+    assert b"Password provider `missing` does not exist" in stderr
+    assert rcode == 1


### PR DESCRIPTION
This PR adds the ability to load passwords or secrets from external providers, rather than relying on bundlewrap to manage secrets. I already use [pass](https://www.passwordstore.org/) for managing my passwords and server secrets, and having to manually reencrypt existing secrets (for example, user passwords which I can't have managed purely in bundlewrap) is tedious (plus I don't like how long the strings are in my templates :grimacing:).

The new `password_from` method accepts an identifier (ie the name of the password to load), as well as an optional external password provider. This provider should be a command that can be interpolated to include the identifier.

This patch also adds a new file called `repo.cfg` for storing repository-wide configuration values; in this case the list of external password providers as well as the default provider to use if none is specified. I'm not sure if this is the best place to add these config values, but it didn't seem right to add them to .secrets.cfg, so if there is a preferred place to add this configuration without creating a new file, I can refactor that.