### PR TITLE
Fix git_deploy: Do not clobber existing environment

### DIFF
--- a/bundlewrap/items/git_deploy.py
+++ b/bundlewrap/items/git_deploy.py
@@ -1,6 +1,6 @@
 from atexit import register as at_exit
 from hashlib import md5
-from os import getenv, getpid, makedirs, mkdir, remove, rmdir, setpgrp
+from os import environ, getenv, getpid, makedirs, mkdir, remove, rmdir, setpgrp
 from os.path import isfile, join
 from shlex import quote
 from shutil import rmtree
@@ -204,6 +204,8 @@ class GitDeploy(Item):
 
         Returns stdout of the command.
         """
+        git_env = environ.copy()
+        git_env['GIT_TERMINAL_PROMPT'] = '0'
         cmdline = ["git"] + cmdline
         io.debug(_("running '{}' in {}").format(
             " ".join(cmdline),
@@ -212,7 +214,7 @@ class GitDeploy(Item):
         git_process = Popen(
             cmdline,
             cwd=repo_dir,
-            env={'GIT_TERMINAL_PROMPT': '0'},
+            env=git_env,
             preexec_fn=setpgrp,
             stderr=PIPE,
             stdout=PIPE,


### PR DESCRIPTION
This nuked the entire existing env, including variables like
SSH_AGENT_PID, which made Git ask for credentials -- which it can't.

This was broken only recently: https://github.com/bundlewrap/bundlewrap/commit/00b58e28c6b80c1494286377dc1387cf17bedc49#diff-a51d0a8a02830180a5762cfc57e50c2e75e9e57b6d16356d4655c1e555cf3019R215