### PR TITLE
Users: Username must come last

### DIFF
--- a/bundlewrap/items/groups.py
+++ b/bundlewrap/items/groups.py
@@ -60,16 +60,16 @@ class Group(Item):
         else:
             command += "groupadd " if status.must_be_created else "groupmod "
 
+            if self.attributes['gid'] is not None:
+                command += "-g {} ".format(self.attributes['gid'])
+
             if self.node.os == 'freebsd':
                 # FreeBSD expects <name> to be the first argument to
                 # `pw groupadd/mod`, however we can also pass it using -n
                 # instead. Then it is positionally independent.
                 command += "-n "
 
-            command += f"{self.name} "
-
-            if self.attributes['gid'] is not None:
-                command += "-g {}".format(self.attributes['gid'])
+            command += f"{self.name}"
         self.run(command, may_fail=True)
 
     def sdict(self):

--- a/bundlewrap/items/groups.py
+++ b/bundlewrap/items/groups.py
@@ -59,6 +59,13 @@ class Group(Item):
             command += f"groupdel {self.name}"
         else:
             command += "groupadd " if status.must_be_created else "groupmod "
+
+            if self.node.os == 'freebsd':
+                # FreeBSD expects <name> to be the first argument to
+                # `pw groupadd/mod`, however we can also pass it using -n
+                # instead. Then it is positionally independent.
+                command += "-n "
+
             command += f"{self.name} "
 
             if self.attributes['gid'] is not None:

--- a/bundlewrap/items/users.py
+++ b/bundlewrap/items/users.py
@@ -161,6 +161,12 @@ class User(Item):
                         value = str(self.attributes[attr])
                     command += "{} {} ".format(option, quote(value))
 
+            if self.node.os == 'freebsd':
+                # FreeBSD expects <name> to be the first argument to
+                # `pw useradd/mod`, however we can also pass it using -n
+                # instead. Then it is positionally independent.
+                command += "-n "
+
             command += f"{self.name}"
             self.run(command, data_stdin=stdin, may_fail=True)
 

--- a/bundlewrap/items/users.py
+++ b/bundlewrap/items/users.py
@@ -144,7 +144,6 @@ class User(Item):
             self.run(command.format(self.name), may_fail=True)
         else:
             command += "useradd " if status.must_be_created else "usermod "
-            command += f"{self.name} "
 
             stdin = None
             for attr, option in sorted(_ATTRIBUTE_OPTIONS.items()):
@@ -161,6 +160,8 @@ class User(Item):
                     else:
                         value = str(self.attributes[attr])
                     command += "{} {} ".format(option, quote(value))
+
+            command += f"{self.name}"
             self.run(command, data_stdin=stdin, may_fail=True)
 
     def display_on_create(self, cdict):


### PR DESCRIPTION
On GNU (and probably FreeBSD), the order doesn't matter.

On OpenBSD, creating or modifying users was broken.

-----

This was probably broken since 3f9bdf8fd749d4cba6ffc69fa3c562b6d80d68ce, I’m not sure. I don’t have a FreeBSD box ready, so it would be great, if you, @ThreeFx, could give this PR a spin and see if creating users still works on FreeBSD. Thanks!