### PR TITLE
metagen: Do not run everything again if no reactor ran

### DIFF
--- a/bundlewrap/metagen.py
+++ b/bundlewrap/metagen.py
@@ -213,6 +213,10 @@ class MetadataGenerator:
     # should we collect information for `bw plot reactors`?
     _record_reactor_call_graph = False
 
+    # This only exists to make DeepSource happy
+    def __init__(self):
+        self._some_reactor_ran = False
+
     def __reset(self):
         # reactors that raised DoNotRunAgain
         self.__do_not_run_again = set()
@@ -240,6 +244,8 @@ class MetadataGenerator:
         self._additional_path_requested = False
         # bw plot reactors
         self._reactor_call_graph = set()
+        # To find out if we can skip a final "__run_nodes()"
+        self._some_reactor_ran = False
 
     def _metadata_proxy_for_node(self, node_name):
         if node_name not in self._node_metadata_proxies:
@@ -285,7 +291,6 @@ class MetadataGenerator:
 
         self.__reset()
         self.__nodes_that_never_ran.add(initial_node_name)
-        self._some_reactor_ran = False
 
         while not QUIT_EVENT.is_set():
             jobmsg = _("{b} ({n} nodes, {r} reactors, {e} runs)").format(

--- a/bundlewrap/repo.py
+++ b/bundlewrap/repo.py
@@ -197,6 +197,7 @@ class Repository(MetadataGenerator):
         # required by MetadataGenerator
         self._node_metadata_proxies = {}
         self._node_metadata_lock = RLock()
+        self._some_reactor_ran = False
 
         if repo_path is not None:
             self.populate_from_path(self.path)

--- a/bundlewrap/repo.py
+++ b/bundlewrap/repo.py
@@ -181,6 +181,8 @@ class LibsProxy:
 
 class Repository(MetadataGenerator):
     def __init__(self, repo_path=None):
+        super().__init__()
+
         if repo_path is None:
             self.path = "/dev/null"
         else:
@@ -197,7 +199,6 @@ class Repository(MetadataGenerator):
         # required by MetadataGenerator
         self._node_metadata_proxies = {}
         self._node_metadata_lock = RLock()
-        self._some_reactor_ran = False
 
         if repo_path is not None:
             self.populate_from_path(self.path)


### PR DESCRIPTION
This saves quite some time on our big repo (`bw hash icinga2` from 5.5 minutes / 1.1 TC to 4 minutes / 0.8 TC, TC being “tera cycles” according to `perf stat`).

All the hashes of `bw hash` and `bw hash -m` commands that I ran remained the same, but I’m still running some more at the moment.