### PR TITLE
Use isoformat() in debug log

### DIFF
--- a/bundlewrap/utils/ui.py
+++ b/bundlewrap/utils/ui.py
@@ -43,7 +43,7 @@ def add_debug_timestamp(f):
     @wraps(f)
     def wrapped(self, msg, **kwargs):
         if self.debug_mode:
-            msg = datetime.now().strftime("[%Y-%m-%d %H:%M:%S.%f] ") + msg
+            msg = "[" + datetime.now().isoformat() + "] " + msg
         return f(self, msg, **kwargs)
     return wrapped
 
@@ -54,7 +54,7 @@ def capture_for_debug_logfile(f):
         if self.debug_log_file and self._active:
             with self.lock:
                 self.debug_log_file.write(
-                    datetime.now().strftime("[%Y-%m-%d %H:%M:%S.%f] ") +
+                    "[" + datetime.now().isoformat() + "] " +
                     ansi_clean(msg).rstrip("\n") + "\n"
                 )
         return f(self, msg, **kwargs)

--- a/bundlewrap/utils/ui.py
+++ b/bundlewrap/utils/ui.py
@@ -43,7 +43,7 @@ def add_debug_timestamp(f):
     @wraps(f)
     def wrapped(self, msg, **kwargs):
         if self.debug_mode:
-            msg = "[" + datetime.now().isoformat() + "] " + msg
+            msg = f"[{datetime.now().isoformat()}] {msg}"
         return f(self, msg, **kwargs)
     return wrapped
 
@@ -53,9 +53,9 @@ def capture_for_debug_logfile(f):
     def wrapped(self, msg, **kwargs):
         if self.debug_log_file and self._active:
             with self.lock:
+                clean_msg = ansi_clean(msg).rstrip("\n")
                 self.debug_log_file.write(
-                    "[" + datetime.now().isoformat() + "] " +
-                    ansi_clean(msg).rstrip("\n") + "\n"
+                    f"[{datetime.now().isoformat()}] {clean_msg}\n"
                 )
         return f(self, msg, **kwargs)
     return wrapped


### PR DESCRIPTION
strftime() is expensive and isoformat() shows almost the same
information, the difference being that annoying "T" from ISO8601.

For large log output (couple of hundred MB), this can shave off a few
billion CPU cycles. It's not a lot, but it's something.