### PR TITLE
Make "rendered in" lines easier to work with

### DIFF
--- a/bundlewrap/items/files.py
+++ b/bundlewrap/items/files.py
@@ -63,7 +63,7 @@ def content_processor_jinja2(item):
             node=item.node.name,
         ))
     duration = datetime.now() - start
-    io.debug("{node}:{bundle}:{item}: rendered in {time}s".format(
+    io.debug("{node}:{bundle}:{item}: rendered in {time:.09f} s".format(
         bundle=item.bundle.name,
         item=item.id,
         node=item.node.name,
@@ -113,7 +113,7 @@ def content_processor_mako(item):
             node=item.node.name,
         ))
     duration = datetime.now() - start
-    io.debug("{node}:{bundle}:{item}: rendered in {time}s".format(
+    io.debug("{node}:{bundle}:{item}: rendered in {time:.09f} s".format(
         bundle=item.bundle.name,
         item=item.id,
         node=item.node.name,


### PR DESCRIPTION
-   Scientific notation is not compatible with sort(1), so just print
    everything as plain floats.
-   If the "s" is put directly after the number, you can't just use
    something like `awk '/rendered in/ { print $4 }' | sort -n`, but
    you have to take an extra step to separate the number and the "s".