### PR TITLE
Fix "job" lines being cut off too early

### DIFF
--- a/bundlewrap/utils/text.py
+++ b/bundlewrap/utils/text.py
@@ -278,3 +278,19 @@ def toml_clean(s):
             previous = ""
         result.append(line)
     return "\n".join(result) + "\n"
+
+
+def trim_visible_len_to(line, target_len):
+    use_until = 0
+    visible_len = 0
+    in_sequence = False
+    while use_until < len(line) and visible_len < target_len:
+        if line[use_until] == "\033":
+            in_sequence = True
+        elif in_sequence and line[use_until] == "m":
+            in_sequence = False
+        elif not in_sequence:
+            visible_len += 1
+        use_until += 1
+
+    return line[:use_until]

--- a/bundlewrap/utils/ui.py
+++ b/bundlewrap/utils/ui.py
@@ -22,6 +22,7 @@ from .text import (
     bold,
     format_duration,
     mark_for_translation as _,
+    trim_visible_len_to,
 )
 
 
@@ -408,8 +409,6 @@ class IOManager:
     def _write_current_job(self):
         if self.jobs and TTY:
             line = "{} ".format(blue(self._spinner_character()))
-            # must track line length manually as len() will count ANSI escape codes
-            visible_length = 2
             try:
                 progress = (self.progress / float(self.progress_total))
             except ZeroDivisionError:
@@ -417,9 +416,11 @@ class IOManager:
             else:
                 progress_text = "{:.1f}%  ".format(progress * 100)
                 line += bold(progress_text)
-                visible_length += len(progress_text)
-            line += self.jobs[-1][:get_terminal_size().columns - 1 - visible_length]
-            write_to_stream(STDOUT_WRITER, line)
+            line += self.jobs[-1]
+            write_to_stream(
+                STDOUT_WRITER,
+                trim_visible_len_to(line, get_terminal_size().columns),
+            )
             self._status_line_present = True
 
 

--- a/tests/unit/utils_text.py
+++ b/tests/unit/utils_text.py
@@ -6,6 +6,7 @@ from bundlewrap.utils.text import (
     format_duration,
     red,
     parse_duration,
+    trim_visible_len_to,
 )
 
 
@@ -45,3 +46,12 @@ def test_parse_format_inverse():
         "1d 4h 7s",
     ):
         assert format_duration(parse_duration(duration)) == duration
+
+
+def test_trim_visible_len_to():
+    assert trim_visible_len_to("foo bar", 10) == "foo bar"
+    assert trim_visible_len_to("foo bar", 3) == "foo"
+    assert trim_visible_len_to("\033[1mfoo bar", 3) == "\033[1mfoo"
+    assert trim_visible_len_to("foo \033[1mbar\033[0m", 4) == "foo "
+    assert trim_visible_len_to("foo \033[1mbar\033[0m", 5) == "foo \033[1mb"
+    assert trim_visible_len_to("föö \033[1mbär\033[0m", 7) == "föö \033[1mbär"


### PR DESCRIPTION
On narrow terminals, the status line showing the current job was being
cut off, because we counted escape sequences as visible characters.