### PR TITLE
update docs: update items.py.md: document when_creating in builtin items aswell

### DIFF
--- a/docs/content/repo/items.py.md
+++ b/docs/content/repo/items.py.md
@@ -46,7 +46,6 @@ This table lists all item types included in BundleWrap along with the bundle att
 <tr><td><a href="../../items/pkg_dnf">pkg_dnf</a></td><td><code>pkg_dnf</code></td><td>Installs and removes packages with dnf</td></tr>
 <tr><td><a href="../../items/pkg_opkg">pkg_opkg</a></td><td><code>pkg_opkg</code></td><td>Installs and removes packages with opkg</td></tr>
 <tr><td><a href="../../items/pkg_pacman">pkg_pacman</a></td><td><code>pkg_pacman</code></td><td>Installs and removes packages with pacman</td></tr>
-<tr><td><a href="../../items/pkg_pamac">pkg_pamac</a></td><td><code>pkg_pamac</code></td><td>Installs and removes packages with pamac</td></tr>
 <tr><td><a href="../../items/pkg_pip">pkg_pip</a></td><td><code>pkg_pip</code></td><td>Installs and removes Python packages with pip</td></tr>
 <tr><td><a href="../../items/pkg_snap">pkg_snap</a></td><td><code>pkg_snap</code></td><td>Installs and removes packages with snap</td></tr>
 <tr><td><a href="../../items/pkg_yum">pkg_yum</a></td><td><code>pkg_yum</code></td><td>Installs and removes packages with yum</td></tr>


### PR DESCRIPTION
Currently, `when_creating` is only documented in postgres_db.md, pkg_apt.md, zfs_pool.md.
However, source code states that this is a "global" attribute, that is builtin in every item.
It should thus be documented where it belongs.