### PR TITLE
Sets of tuples 1/2: deepcopy_metadata() preserves tuples

### DIFF
--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -46,6 +46,8 @@ def deepcopy_metadata(obj):
             new_obj = []
         for member in obj:
             new_obj.append(deepcopy_metadata(member))
+        if isinstance(obj, tuple):
+            new_obj = tuple(new_obj)
     elif isinstance(obj, set):
         if isinstance(obj, ATOMIC_TYPES[set]):
             new_obj = atomic(set())


### PR DESCRIPTION
Currently, metadata like
```
{
    'foo': {
        ('a', 'b'),
        ('c', 'd'),
    }
}
```
is not possible, because tuples are converted to lists in deepcopy_metadata(). As lists are not hashable, we can not have sets of tuples. This PR makes deepcopy_metadata() preserve tuples.