### PR TITLE
Do more package items need "block concurrent runs"?

### DIFF
--- a/bundlewrap/items/pkg_pip.py
+++ b/bundlewrap/items/pkg_pip.py
@@ -17,6 +17,10 @@ class PipPkg(Item):
     }
     ITEM_TYPE_NAME = "pkg_pip"
 
+    @classmethod
+    def block_concurrent(cls, node_os, node_os_version):
+        return [cls.ITEM_TYPE_NAME]
+
     def __repr__(self):
         return "<PipPkg name:{} installed:{}>".format(
             self.name,


### PR DESCRIPTION
A couple of items allow multiple runs in parallel. This might work if you're installing multiple *different* packages, but what if those package pull in the *same* dependencies? I can't imagine that that's healthy. 🤔

This PR only changes `pkg_pip`, but there's more. Let's discuss first, though.