### PR TITLE
items/zfs_dataset: explicitely set mountpoint and canmount, if not already specified

### DIFF
--- a/bundlewrap/items/zfs_dataset.py
+++ b/bundlewrap/items/zfs_dataset.py
@@ -137,3 +137,17 @@ class ZFSDataset(Item):
             sdict[option] = self.__get_option(self.name, option)
         sdict['mounted'] = self.__get_option(self.name, 'mounted')
         return sdict
+
+    def patch_attributes(self, attributes):
+        # If no mountpoint was specified, explicitely set it to 'none'.
+        # Also, set `canmount` to 'off', so we don't accidentially mount
+        # it.
+        if 'canmount' not in attributes:
+            if not attributes.get('mountpoint'):
+                attributes['canmount'] = 'off'
+            else:
+                attributes['canmount'] = 'on'
+        if not attributes.get('mountpoint'):
+            attributes['mountpoint'] = 'none'
+        return attributes
+


### PR DESCRIPTION
This fixes an issue on some systems, if you had `tank/myapp` and `tank/myapp/somewhere`, but only mounted the latter dataset. The item wouldn't specify a mountpoint for `tank/myapp`, resulting in mounting the dataset to `/tank/myapp`.

That alone wouldn't be a problem, but bundlewrap then sees 'oh, that dataset is mounted, but shouldn't be, lets unmount it'. Unmounting fails, because `tank/myapp/somewhere` is still mounted (as wanted).