### PR TITLE
Use rtoml for normal loading

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/bundlewrap/repo.py
+++ b/bundlewrap/repo.py
@@ -5,7 +5,7 @@ from os import listdir, mkdir, walk
 from os.path import abspath, dirname, isdir, isfile, join
 
 from pkg_resources import DistributionNotFound, require, VersionConflict
-from tomlkit import parse as toml_parse
+from rtoml import load as toml_load
 
 from . import items, VERSION_STRING
 from .bundle import FILENAME_ITEMS
@@ -27,7 +27,7 @@ from .utils import (
     names,
 )
 from .utils.scm import get_git_branch, get_git_clean, get_rev
-from .utils.dicts import hash_statedict, untoml
+from .utils.dicts import hash_statedict
 from .utils.text import mark_for_translation as _, red, validate_name
 from .utils.ui import io
 
@@ -367,7 +367,7 @@ class Repository(MetadataGenerator):
                         filename.startswith("_"):
                     continue
                 with error_context(filepath=filepath):
-                    infodict = untoml(toml_parse(get_file_contents(filepath)))
+                    infodict = toml_load(get_file_contents(filepath).decode())
                 infodict['file_path'] = filepath
                 yield filename[:-5], infodict
 

--- a/bundlewrap/utils/dicts.py
+++ b/bundlewrap/utils/dicts.py
@@ -1,5 +1,4 @@
 from copy import copy
-from datetime import datetime, date, time
 from difflib import unified_diff
 from hashlib import sha1
 from json import dumps, JSONEncoder

--- a/bundlewrap/utils/dicts.py
+++ b/bundlewrap/utils/dicts.py
@@ -5,8 +5,6 @@ from hashlib import sha1
 from json import dumps, JSONEncoder
 
 from tomlkit import document as toml_document
-from tomlkit import items as toml_types
-from tomlkit.container import Container as TOMLContainer
 
 from . import Fault
 from .text import bold, green, red, yellow
@@ -504,31 +502,3 @@ def value_at_key_path(dict_obj, path):
             raise KeyError("/".join(path))
         else:
             return value_at_key_path(nested_dict, remaining_path)
-
-
-TOML_TYPES = {
-    toml_types.Bool: bool,
-    toml_types.Float: float,
-    toml_types.Integer: int,
-    toml_types.Table: dict,
-    toml_types.String: str,
-    toml_types.DateTime: datetime,
-    toml_types.Date: date,
-    toml_types.Time: time,
-}
-
-
-def untoml(obj):
-    if isinstance(obj, (dict, TOMLContainer)):
-        return {key: untoml(value) for key, value in obj.items()}
-    elif isinstance(obj, set):
-        return {untoml(value) for value in obj}
-    elif isinstance(obj, list):
-        return [untoml(value) for value in obj]
-    elif isinstance(obj, tuple):
-        return tuple(untoml(value) for value in obj)
-    elif isinstance(obj, toml_types.Item):
-        for toml_type, native_type in TOML_TYPES.items():
-            if isinstance(obj, toml_type):
-                return native_type(obj)
-    return obj

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "requests >= 1.0.0",
         "librouteros >= 3.0.0",
         "tomlkit",
+        "rtoml",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
tomlkit has performance issues.

untoml() has been removed, because it was not part of the official API
documented here: https://docs.bundlewrap.org/guide/api/#reference