### PR TITLE
doc: Mnemonics for cdict and sdict

### DIFF
--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -676,8 +676,9 @@ class Item:
     def cdict(self):
         """
         Return a statedict that describes the target state of this item
-        as configured in the repo. Returning `None` instead means that
-        the item should not exist.
+        as configured in the repo (mnemonic: _c_dict for _config_
+        dict). Returning `None` instead means that the item should
+        not exist.
 
         MAY be overridden by subclasses.
         """
@@ -885,8 +886,9 @@ class Item:
     def sdict(self):
         """
         Return a statedict that describes the actual state of this item
-        on the node. Returning `None` instead means that the item does
-        not exist on the node.
+        on the node (mnemonic: _s_dict for _state_ dict). Returning
+        `None` instead means that the item does not exist on the
+        node.
 
         For the item to validate as correct, the values for all keys in
         self.cdict() have to match this statedict.

--- a/docs/content/guide/dev_item.md
+++ b/docs/content/guide/dev_item.md
@@ -50,8 +50,9 @@ Create a new file called `/your/bundlewrap/repo/items/foo.py`. You can use this 
         def cdict(self):
             """
             Return a statedict that describes the target state of this item
-            as configured in the repo. Returning `None` instead means that
-            the item should not exist.
+            as configured in the repo (mnemonic: _c_dict for _config_
+            dict). Returning `None` instead means that the item should
+            not exist.
 
             Implementing this method is optional. The default implementation
             uses the attributes as defined in the bundle.
@@ -61,8 +62,9 @@ Create a new file called `/your/bundlewrap/repo/items/foo.py`. You can use this 
         def sdict(self):
             """
             Return a statedict that describes the actual state of this item
-            on the node. Returning `None` instead means that the item does
-            not exist on the node.
+            on the node (mnemonic: _s_dict for _state_ dict). Returning
+            `None` instead means that the item does not exist on the
+            node.
 
             For the item to validate as correct, the values for all keys in
             self.cdict() have to match this statedict.


### PR DESCRIPTION
IMHO, `cdict` and `sdict` are not such great names. 🥴 It is not obvious what they mean. In the beginning, I thought `cdict` meant “*current* dict” and `sdict` meant “*should (be)* dict”, which is the wrong way around. I heard from other people that they mix up the dicts very often.

So, apparently `cdict` stands for “config dict”, so it’s a dict describing the *configuration* in your repo. Whereas `sdict` stands for … what does it stand for? 🥴 If thought it was “statedict”, but the [docs](https://docs.bundlewrap.org/guide/dev_item/) start with:

> To represent supposed vs. actual state, BundleWrap uses statedicts.

So, both `cdict` and `sdict` are “statedicts”? What’s `sdict` then?

I still went with “_s_dict stands for _state_ dict”, because this makes sense in the context of the sentence.

(If I were to choose new names, I’d go with `state_on_node` instead of `sdict` and `state_as_configured` instead of `cdict`.)