### PR TITLE
"bw items -w" should not try to preview downloads

### DIFF
--- a/bundlewrap/cmdline/items.py
+++ b/bundlewrap/cmdline/items.py
@@ -54,6 +54,11 @@ def bw_items(repo, args):
                     "{x} skipped {filename} (content_type 'binary')"
                 ).format(x=yellow("»"), filename=bold(item.name)))
                 continue
+            if item.attributes['content_type'] == 'download':
+                io.stderr(_(
+                    "{x} skipped {filename} (content_type 'download')"
+                ).format(x=yellow("»"), filename=bold(item.name)))
+                continue
             if item.attributes['delete']:
                 io.stderr(_(
                     "{x} skipped {filename} ('delete' attribute set)"


### PR DESCRIPTION
a) It fails, b) there is nothing to preview as these are no templates (just like "binary" files).

This was the original error:

```
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.10/site-packages/bundlewrap/utils/cmdline.py", line 69, in wrapper
    return f(*args, **kwargs)
  File "/home/user/.local/lib/python3.10/site-packages/bundlewrap/cmdline/__init__.py", line 77, in main
    pargs.func(repo, text_pargs)
  File "/home/user/.local/lib/python3.10/site-packages/bundlewrap/cmdline/items.py", line 63, in bw_items
    write_preview(item, args['file_preview_path'])
  File "/home/user/.local/lib/python3.10/site-packages/bundlewrap/cmdline/items.py", line 21, in write_preview
    content = file_item.content
  File "/home/user/.local/lib/python3.10/site-packages/bundlewrap/utils/__init__.py", line 36, in cache_wrapper
    return_value = prop(self)
  File "/home/user/.local/lib/python3.10/site-packages/bundlewrap/items/files.py", line 265, in content
    return CONTENT_PROCESSORS[self.attributes['content_type']](self)
TypeError: 'NoneType' object is not callable
```