### PR TITLE
Allow removal of essentials with pkg_apt

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Rico Ullmann <rico@erinnerungsfragmente.de>
 Christian Nicolai <chrnicolai@gmail.com>
 Galen Abell <galen@galenabell.com>
 Franziska Kunsmann <github@kunsmann.eu>
+Hex Sattler <hi@chaoswit.ch>

--- a/bundlewrap/items/pkg_apt.py
+++ b/bundlewrap/items/pkg_apt.py
@@ -54,7 +54,8 @@ class AptPkg(Pkg):
     def pkg_remove(self):
         self.run(
             "DEBIAN_FRONTEND=noninteractive "
-            "apt-get -qy purge {}".format(quote(self.name.replace("_", ":")))
+            "apt-get -qy --allow-remove-essential "
+            "purge {}".format(quote(self.name.replace("_", ":")))
         )
 
     @classmethod


### PR DESCRIPTION
Currently, there is no way to remove essential packages. This change allows to do so by executing all purges with --allow-remove-essential.