### PR TITLE
routeros: Drop connections on errors

### DIFF
--- a/bundlewrap/items/routeros.py
+++ b/bundlewrap/items/routeros.py
@@ -116,6 +116,7 @@ class RouterOS(Item):
                 username=str(self.node.username),
                 password=str(self.node.password or ""),
                 host=self.node.hostname,
+                timeout=120.0,
             )
             CONNECTIONS[self.node] = connection
         return connection


### PR DESCRIPTION
We *think* we saw this:

-   We bombarded a switch with 64 requests at once.
-   The switch took more than 10 seconds to respond for one of those
    requests. This triggers librouteros's timeout during recv().
-   Data for that request might still arrive later on the socket, so one
    of the next invocations of rawCmd() gets a completely unrelated
    answer.