### PR TITLE
SSH argument "username" missing in some places

### DIFF
--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -892,7 +892,12 @@ class Node:
             if self._ssh_first_conn_lock.acquire(False):
                 try:
                     with io.job(_("{}  establishing connection...").format(bold(self.name))):
-                        operations.run(self.hostname, "true", add_host_keys=self._add_host_keys)
+                        operations.run(
+                            self.hostname,
+                            "true",
+                            add_host_keys=self._add_host_keys,
+                            username=self.username,
+                        )
                     self._ssh_conn_established = True
                 finally:
                     self._ssh_first_conn_lock.release()

--- a/bundlewrap/operations.py
+++ b/bundlewrap/operations.py
@@ -313,6 +313,7 @@ def upload(
             ),
             add_host_keys=add_host_keys,
             ignore_failure=ignore_failure,
+            username=username,
             wrapper_inner=wrapper_inner,
             wrapper_outer=wrapper_outer,
         )
@@ -328,6 +329,7 @@ def upload(
             ),
             add_host_keys=add_host_keys,
             ignore_failure=ignore_failure,
+            username=username,
             wrapper_inner=wrapper_inner,
             wrapper_outer=wrapper_outer,
         )
@@ -342,6 +344,7 @@ def upload(
         ),
         add_host_keys=add_host_keys,
         ignore_failure=ignore_failure,
+        username=username,
         wrapper_inner=wrapper_inner,
         wrapper_outer=wrapper_outer,
     )


### PR DESCRIPTION
For example: Applying a node with `username` overridden node fails because the `scp` runs *with* the desired `username`, but the following `mv` (which uses a path *relative* to the user’s home) runs *without* `username`.

If this never showed up before, I’m probably the first person to use this feature? 🥴