### PR TITLE
svc_systemd: Fix svc_enabled()

### DIFF
--- a/bundlewrap/items/svc_systemd.py
+++ b/bundlewrap/items/svc_systemd.py
@@ -32,7 +32,7 @@ def svc_enabled(node, svcname):
     )
     return (
         result.return_code == 0 and
-        force_text(result.stdout).strip() != "runtime-enabled"
+        force_text(result.stdout).strip() != "enabled-runtime"
     )
 
 


### PR DESCRIPTION
I don't know where the string "runtime-enabled" comes from. It has been called "enabled-runtime" in their manpage since at least 2013.

"runtime-enabled" worked on Ubuntu 18.04, but that's the only reference to it that I can find. It no longer does on Ubuntu 22.04, though.