### PR TITLE
bw pw -f: Allow for binary files

### DIFF
--- a/bundlewrap/cmdline/pw.py
+++ b/bundlewrap/cmdline/pw.py
@@ -48,9 +48,10 @@ def bw_pw(repo, args):
             content = repo.vault.decrypt_file(
                 args['string'],
                 key=args['key'],
+                binary=True,
             ).value
             with open(join(repo.data_dir, args['file']), 'wb') as f:
-                f.write(content.encode('utf-8'))
+                f.write(content)
         else:
             try:
                 key, cryptotext = args['string'].split("$", 1)

--- a/bundlewrap/secrets.py
+++ b/bundlewrap/secrets.py
@@ -81,7 +81,7 @@ class SecretProxy:
         key, cryptotext = self._determine_key_to_use(cryptotext.encode('utf-8'), key, cryptotext)
         return Fernet(key).decrypt(cryptotext).decode('utf-8')
 
-    def _decrypt_file(self, source_path=None, key=None):
+    def _decrypt_file(self, source_path=None, binary=False, key=None):
         """
         Decrypts the file at source_path (relative to data/) and
         returns the plaintext as unicode.
@@ -93,7 +93,10 @@ class SecretProxy:
         key, cryptotext = self._determine_key_to_use(cryptotext, key, source_path)
 
         f = Fernet(key)
-        return f.decrypt(cryptotext).decode('utf-8')
+        if binary:
+            return f.decrypt(cryptotext)
+        else:
+            return f.decrypt(cryptotext).decode('utf-8')
 
     def _decrypt_file_as_base64(self, source_path=None, key=None):
         """
@@ -287,11 +290,12 @@ class SecretProxy:
             key=key,
         )
 
-    def decrypt_file(self, source_path, key=None):
+    def decrypt_file(self, source_path, binary=False, key=None):
         return Fault(
             'bw secrets decrypt_file',
             self._decrypt_file,
             source_path=source_path,
+            binary=binary,
             key=key,
         )
 

--- a/tests/integration/bw_pw.py
+++ b/tests/integration/bw_pw.py
@@ -80,6 +80,31 @@ def test_encrypt_file_different_key_autodetect(tmpdir):
         assert f.read() == "ohai"
 
 
+def test_encrypt_file_binary(tmpdir):
+    make_repo(tmpdir)
+
+    source_file = join(str(tmpdir), "data", "source")
+    with open(source_file, 'wb') as f:
+        f.write(b"\000\001\002")
+
+    stdout, stderr, rcode = run(
+        f"bw pw -e -f encrypted \"{source_file}\"",
+        path=str(tmpdir),
+    )
+    assert stderr == b""
+    assert rcode == 0
+
+    stdout, stderr, rcode = run(
+        "bw pw -d -f decrypted encrypted",
+        path=str(tmpdir),
+    )
+    assert stdout == b""
+    assert stderr == b""
+    assert rcode == 0
+    with open(join(tmpdir, "data", "decrypted"), 'rb') as f:
+        assert f.read() == b"\000\001\002"
+
+
 def test_human_password(tmpdir):
     make_repo(tmpdir)
 


### PR DESCRIPTION
Encrypting always worked. With this patch, decrypting does, too:

```
$ dd if=/dev/urandom of=myfile bs=1M count=1 && md5sum myfile && bw pw -e -f myfile.vault myfile && rm myfile && bw pw -d -f myfile myfile.vault && md5sum myfile
1+0 records in
1+0 records out
1048576 bytes (1.0 MB, 1.0 MiB) copied, 0.00501153 s, 209 MB/s
191b44f97abe8901b002b52865e2ba9c  myfile
191b44f97abe8901b002b52865e2ba9c  myfile
```

To be honest, it feels a bit like a hack, though. The content is wrapped in a `Fault` and it doesn’t look like that class is supposed to deal with `bytes`, is it? 🤔