### PR TITLE
Integration tests: Always check returncode of run()

### DIFF
--- a/tests/integration/bw_apply_actions.py
+++ b/tests/integration/bw_apply_actions.py
@@ -22,7 +22,8 @@ def test_action_success(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
 
 
 def test_action_fail(tmpdir):
@@ -46,7 +47,8 @@ def test_action_fail(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 1
 
 
 def test_action_pipe_binary(tmpdir):
@@ -72,7 +74,8 @@ def test_action_pipe_binary(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
 
 
 def test_action_pipe_utf8(tmpdir):
@@ -98,7 +101,8 @@ def test_action_pipe_utf8(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
 
 
 def test_action_return_codes(tmpdir):
@@ -135,4 +139,5 @@ def test_action_return_codes(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0

--- a/tests/integration/bw_apply_autoonly.py
+++ b/tests/integration/bw_apply_autoonly.py
@@ -38,7 +38,8 @@ def test_only_bundle_with_dep(tmpdir):
         },
     )
 
-    run("bw apply -o bundle:test -- localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply -o bundle:test -- localhost", path=str(tmpdir))
+    assert rcode == 0
     assert exists(join(str(tmpdir), "foo"))
     assert exists(join(str(tmpdir), "bar"))
     assert not exists(join(str(tmpdir), "baz"))

--- a/tests/integration/bw_apply_directories.py
+++ b/tests/integration/bw_apply_directories.py
@@ -43,7 +43,8 @@ def test_purge(tmpdir):
     with open(join(str(tmpdir), "purgedir", "subdir3", "unmanaged_file"), 'w') as f:
         f.write("content")
 
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
 
     assert not exists(join(str(tmpdir), "purgedir", "unmanaged_file"))
     assert not exists(join(str(tmpdir), "purgedir", "subdir3", "unmanaged_file"))
@@ -91,7 +92,8 @@ def test_purge_special_chars(tmpdir):
     with open(join(str(tmpdir), "purgedir", "unmanaged_:'_file"), 'w') as f:
         f.write("content")
 
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
 
     assert not exists(join(str(tmpdir), "purgedir", "unmänäged_file"))
     assert not exists(join(str(tmpdir), "purgedir", "unmanaged_`uname`_file"))

--- a/tests/integration/bw_apply_files.py
+++ b/tests/integration/bw_apply_files.py
@@ -26,7 +26,9 @@ def test_any_content_create(tmpdir):
         },
     )
 
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "foo"), 'rb') as f:
         content = f.read()
     assert content == b""
@@ -56,7 +58,9 @@ def test_any_content_exists(tmpdir):
     with open(join(str(tmpdir), "foo"), 'wb') as f:
         f.write(b"existing content")
 
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "foo"), 'rb') as f:
         content = f.read()
     assert content == b"existing content"
@@ -84,7 +88,10 @@ def test_binary_inline_content(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "foo.bin"), 'rb') as f:
         content = f.read()
     assert content.decode('latin-1') == "ö"
@@ -114,7 +121,9 @@ def test_binary_template_content(tmpdir):
     with open(join(str(tmpdir), "bundles", "test", "files", "foo.bin"), 'wb') as f:
         f.write("ö".encode('utf-8'))
 
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "foo.bin"), 'rb') as f:
         content = f.read()
     assert content.decode('latin-1') == "ö"
@@ -143,7 +152,8 @@ def test_delete(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
     assert not exists(join(str(tmpdir), "foo"))
 
 
@@ -169,7 +179,8 @@ def test_mako_template_content(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
     with open(join(str(tmpdir), "foo"), 'rb') as f:
         content = f.read()
     assert content == b"localhost"
@@ -197,7 +208,10 @@ def test_mako_template_content_with_secret(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "foo"), 'rb') as f:
         content = f.read()
     assert content == b"faCTT76kagtDuZE5wnoiD1CxhGKmbgiX"
@@ -225,7 +239,10 @@ def test_text_template_content(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "foo"), 'rb') as f:
         content = f.read()
     assert content == b"${node.name}"

--- a/tests/integration/bw_apply_precedes.py
+++ b/tests/integration/bw_apply_precedes.py
@@ -37,7 +37,10 @@ def test_precedes(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "file")) as f:
         content = f.read()
     assert content == "1\n2\n3\n"
@@ -78,7 +81,10 @@ def test_precedes_unless(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "file")) as f:
         content = f.read()
     assert content == "1\n3\n"
@@ -120,7 +126,8 @@ def test_precedes_unless2(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
     assert not exists(join(str(tmpdir), "file"))
 
 
@@ -159,7 +166,10 @@ def test_precedes_unless3(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "file")) as f:
         content = f.read()
     assert content == "2\n3\n"
@@ -198,7 +208,10 @@ def test_precedes_unless4(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 1  # because of action2
+
     with open(join(str(tmpdir), "file")) as f:
         content = f.read()
     assert content == "1\n"
@@ -230,7 +243,10 @@ def test_precedes_action(tmpdir):
             },
         },
     )
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "file")) as f:
         content = f.read()
     assert content == "1\n2\n"

--- a/tests/integration/bw_apply_secrets.py
+++ b/tests/integration/bw_apply_secrets.py
@@ -26,7 +26,10 @@ files = {{
 }}
 """.format(join(str(tmpdir), "secret")))
 
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "secret")) as f:
         content = f.read()
     assert content == "sQDdTXu5OmCki8gdGgYdfTxooevckXcB"
@@ -55,7 +58,10 @@ def test_fault_content_mako(tmpdir):
         },
     )
 
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "secret")) as f:
         content = f.read()
     assert content == "sQDdTXu5OmCki8gdGgYdfTxooevckXcB"
@@ -89,7 +95,10 @@ nodes = {{
 }}
 """.format(host_os()))
 
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "secret")) as f:
         content = f.read()
     assert content == "sQDdTXu5OmCki8gdGgYdfTxooevckXcB"
@@ -118,7 +127,10 @@ def test_fault_content_jinja2(tmpdir):
         },
     )
 
-    run("bw apply localhost", path=str(tmpdir))
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
     with open(join(str(tmpdir), "secret")) as f:
         content = f.read()
     assert content == "sQDdTXu5OmCki8gdGgYdfTxooevckXcB"

--- a/tests/integration/bw_hash.py
+++ b/tests/integration/bw_hash.py
@@ -8,6 +8,7 @@ def test_empty(tmpdir):
     stdout, stderr, rcode = run("bw hash", path=str(tmpdir))
     assert stdout == b"bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f\n"
     assert stderr == b""
+    assert rcode == 0
 
 
 def test_nondeterministic(tmpdir):
@@ -36,6 +37,7 @@ def test_nondeterministic(tmpdir):
 
     for i in range(3):
         stdout, stderr, rcode = run("bw hash", path=str(tmpdir))
+        assert rcode == 0
         hashes.add(stdout.strip())
 
     assert len(hashes) > 1
@@ -68,6 +70,7 @@ def test_deterministic(tmpdir):
 
     for i in range(3):
         stdout, stderr, rcode = run("bw hash", path=str(tmpdir))
+        assert rcode == 0
         hashes.add(stdout.strip())
 
     assert len(hashes) == 1

--- a/tests/integration/bw_metadata.py
+++ b/tests/integration/bw_metadata.py
@@ -464,6 +464,7 @@ def reactor2(metadata):
         "broken": True,
         "again": True,
     }
+    assert rcode == 0
 
 
 def test_own_node_metadata(tmpdir):
@@ -489,6 +490,7 @@ def reactor1(metadata):
         "number": 47,
         "plusone": 48,
     }
+    assert rcode == 0
 
 
 def test_other_node_metadata(tmpdir):
@@ -522,16 +524,19 @@ def reactor1(metadata):
     return {'other_numbers': numbers}
 """)
     stdout, stderr, rcode = run("bw metadata node1", path=str(tmpdir))
+    assert rcode == 0
     assert loads(stdout.decode()) == {
         "number": 47,
         "other_numbers": [23, 42],
     }
     stdout, stderr, rcode = run("bw metadata node2", path=str(tmpdir))
+    assert rcode == 0
     assert loads(stdout.decode()) == {
         "number": 42,
         "other_numbers": [23, 47],
     }
     stdout, stderr, rcode = run("bw metadata node3", path=str(tmpdir))
+    assert rcode == 0
     assert loads(stdout.decode()) == {
         "number": 23,
         "other_numbers": [42, 47],

--- a/tests/integration/bw_stats.py
+++ b/tests/integration/bw_stats.py
@@ -39,3 +39,4 @@ def test_nondeterministic(tmpdir):
 │     2 │ file              │
 ╰───────┴───────────────────╯
 """.encode('utf-8')
+    assert rcode == 0

--- a/tests/integration/bw_test.py
+++ b/tests/integration/bw_test.py
@@ -38,8 +38,13 @@ def test(repo, **kwargs):
 def test_node(repo, node, **kwargs):
     io.stdout("BBB")
 """)
-    assert b"AAA" in run("bw test -H", path=str(tmpdir))[0]
-    assert b"BBB" in run("bw test -J", path=str(tmpdir))[0]
+    stdout, stderr, rcode = run("bw test -H", path=str(tmpdir))
+    assert rcode == 0
+    assert b"AAA" in stdout
+
+    stdout, stderr, rcode = run("bw test -J", path=str(tmpdir))
+    assert rcode == 0
+    assert b"BBB" in stdout
 
 
 def test_circular_dep_direct(tmpdir):


### PR DESCRIPTION
Note that the tests in bw_apply_actions.py were mostly without effect.

Maybe we should discuss moving this to `run()` itself because it is easy to forget to perform this check. It is a useful check, though, as it can reveal all kinds of unexpected failures.