### PR TITLE
git_deploy: Stop using preexec_fn

### DIFF
--- a/bundlewrap/items/git_deploy.py
+++ b/bundlewrap/items/git_deploy.py
@@ -5,6 +5,7 @@ from os.path import isfile, join
 from shlex import quote
 from shutil import rmtree
 from subprocess import PIPE, Popen
+from sys import version_info
 from tempfile import gettempdir, NamedTemporaryFile
 from time import sleep
 
@@ -211,14 +212,26 @@ class GitDeploy(Item):
             " ".join(cmdline),
             repo_dir,
         ))
-        git_process = Popen(
-            cmdline,
-            cwd=repo_dir,
-            env=git_env,
-            preexec_fn=setpgrp,
-            stderr=PIPE,
-            stdout=PIPE,
-        )
+
+        if version_info < (3, 11):
+            git_process = Popen(
+                cmdline,
+                cwd=repo_dir,
+                env=git_env,
+                preexec_fn=setpgrp,
+                stderr=PIPE,
+                stdout=PIPE,
+            )
+        else:
+            git_process = Popen(
+                cmdline,
+                cwd=repo_dir,
+                env=git_env,
+                process_group=0,
+                stderr=PIPE,
+                stdout=PIPE,
+            )
+
         stdout, stderr = git_process.communicate()
         result = RunResult()
         result.stdout = stdout


### PR DESCRIPTION
Not very relevant for performance here, but preexec_fn is about to be deprecated, so let's just remove it while we're at it.

https://github.com/python/cpython/issues/82616