### PR TITLE
Fix block_concurrent() not working if item provides canned actions

### DIFF
--- a/bundlewrap/deps.py
+++ b/bundlewrap/deps.py
@@ -269,9 +269,13 @@ def _inject_concurrency_blockers(items, node_os, node_os_version):
         ))
         processed_items = set()
         for item in type_items:
-            # disregard deps to items of other types
+            # disregard deps to items of other types and to canned
+            # actions
             item.__deps = set(filter(
-                lambda dep: dep.split(":", 1)[0] in blocked_types,
+                lambda dep: (
+                    dep.split(":", 1)[0] in blocked_types and
+                    dep.count(":") == 1
+                ),
                 item._flattened_deps,
             ))
         previous_item = None


### PR DESCRIPTION
If an item type provides canned actions, item.__deps contained dependencies to those canned actions right from the start. This meant that this construct always returned an empty list ("not item.__deps" was never true):

    list(filter(
        lambda item: not item.__deps and item not in processed_items,
        type_items,
    ))

As a result, concurrency blockers were never inserted for such item types.

Should also fix #554.