### PR TITLE
deps: Optimize _add_incoming_needs()

### DIFF
--- a/bundlewrap/deps.py
+++ b/bundlewrap/deps.py
@@ -125,13 +125,14 @@ def _add_incoming_needs(items):
     For each item, records all items that need that item in
     ._incoming_needs.
     """
+    mapping = {}
     for item in items:
-        item._incoming_needs = set()
-        for depending_item in items:
-            if item == depending_item:
-                continue
-            if item.id in depending_item._flattened_deps_needs:
-                item._incoming_needs.add(depending_item)
+        for other_item_id in item._flattened_deps_needs:
+            mapping.setdefault(other_item_id, set())
+            mapping[other_item_id].add(item)
+
+    for item in items:
+        item._incoming_needs = mapping.get(item.id, set())
 
 
 def _prepare_auto_attrs(items):


### PR DESCRIPTION
This is a quick win, we can easily get rid of the quadratic runtime here.

-   In a repo with one node that has 2000 file items, the runtime of `bw test node-1` drops from ~8.4 seconds to ~4.7 seconds.
-   The “processing dependencies” stage of our Icinga node drops from ~32 seconds to ~21 seconds.