### PR TITLE
Timeouts and HEAD requests for file downloads

### DIFF
--- a/bundlewrap/items/files.py
+++ b/bundlewrap/items/files.py
@@ -3,7 +3,10 @@ from base64 import b64decode
 from collections import defaultdict
 from contextlib import contextmanager, suppress
 from datetime import datetime
-from functools import cache
+try:
+    from functools import cache
+except ImportError:  # Python 3.8
+    cache = lambda f: f
 from hashlib import md5
 from os import getenv, getpid, makedirs, mkdir, rmdir
 from os.path import basename, dirname, exists, isfile, join, normpath

--- a/bundlewrap/utils/__init__.py
+++ b/bundlewrap/utils/__init__.py
@@ -59,14 +59,14 @@ def cached_property_set(prop):
     return cached_property(prop, convert_to=set)
 
 
-def download(url, path):
+def download(url, path, timeout=60.0):
     with error_context(url=url, path=path):
         if not exists(dirname(path)):
             makedirs(dirname(path))
         if exists(path):
             chmod(path, MODE644)
         with open(path, 'wb') as f:
-            r = get(url, stream=True)
+            r = get(url, stream=True, timeout=timeout)
             r.raise_for_status()
             for block in r.iter_content(1024):
                 if not block:

--- a/docs/content/items/file.md
+++ b/docs/content/items/file.md
@@ -56,6 +56,12 @@ When set to `True`, the path of this file will be removed. It doesn't matter if 
 
 <hr>
 
+## download_timeout
+
+Only valid if `content_type` is set to `download`. This value can be set to a number of seconds after which an error is thrown if the remote server no longer provides a response. This does NOT limit the total duration of the download. Defaults to `60.0`.
+
+<hr>
+
 ## encoding
 
 Encoding of the target file. Note that this applies to the remote file only, your template is still conveniently written in UTF-8 and will be converted by BundleWrap. Defaults to "utf-8". Other possible values (e.g. "latin-1") can be found [here](http://docs.python.org/2/library/codecs.html#standard-encodings). Only allowed with `content_type` `jinja2`, `mako`, or `text`.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "Natural Language :: English",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.8",  # remove hack in files.py import when EOL
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
addresses #749 and replaces #748

This will add a global default download timeout of 60s. Not having a timeout there before is problematic enough that I don't care about backwards compatibility here. I doubt anyone relies on bw blocking forever. If for some reason a downloaded file needs a longer timeout (because it takes time to generate it server-side for example), this can now be addressed at item level with the new `download_timeout` attribute.

Also if `content_hash` is not set for a download file item, the URL will only be checked with a HEAD request instead of downloading the complete file just to throw it away.