### PR TITLE
items/files: show url instead of nodename+path when downloading file

### DIFF
--- a/bundlewrap/items/files.py
+++ b/bundlewrap/items/files.py
@@ -184,10 +184,10 @@ def download_file(item):
                 f"starting download from {item.attributes['source']}"
             )
             with io.job(_("{node}  {item}  downloading from {url}").format(
-              node=bold(item.node.name), 
-              item=bold(item.id),
-              url=item.attributes['source'],
-            ):
+                node=bold(item.node.name), 
+                item=bold(item.id),
+                url=item.attributes['source'],
+            )):
                 download(
                     item.attributes['source'],
                     file_path,

--- a/bundlewrap/items/files.py
+++ b/bundlewrap/items/files.py
@@ -168,7 +168,7 @@ def download_file(item):
                 f"{item.node.name}:{item.id}: "
                 f"starting download from {item.attributes['source']}"
             )
-            with io.job(_("{}  {}  downloading file".format(bold(item.node.name), bold(item.id)))):
+            with io.job(_("{}  downloading file".format(bold(item.attributes['source'])))):
                 download(item.attributes['source'], file_path)
             io.debug(
                 f"{item.node.name}:{item.id}: "


### PR DESCRIPTION
Showing the node name and the file path seemed to be the correct thing initially, however i've found that showing that info is often not what users expect.

Showing the actual url that's being downloaded is much more intuitive to users. Especially inexperienced bw users have contacted me and asked why bundlewrap was downloading a file from the node when it should be *uploading* that file instead.