### PR TITLE
show skipped items at the end of the apply

### DIFF
--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -136,7 +136,7 @@ class Item:
     SKIP_REASON_DESC = {
         SKIP_REASON_CMDLINE: _("cmdline"),
         SKIP_REASON_DEP_FAILED: _("dependency failed"),
-        SKIP_REASON_FAULT_UNAVAILABLE: _("Fault unavailable"),
+        SKIP_REASON_FAULT_UNAVAILABLE: _("Fault unavailable: {}"),
         SKIP_REASON_INTERACTIVE: _("declined interactively"),
         SKIP_REASON_INTERACTIVE_ONLY: _("interactive only"),
         SKIP_REASON_NO_TRIGGER: _("not triggered"),

--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -546,12 +546,17 @@ class Item:
                     node=self.node.name,
                 ))
                 status_code = self.STATUS_SKIPPED
-                details = self.SKIP_REASON_FAULT_UNAVAILABLE
+                details = (
+                    self.SKIP_REASON_FAULT_UNAVAILABLE,
+                    "missing faults for attributes: {}".format(
+                        ", ".join(sorted(self._faults_missing_for_attributes)),
+                    ),
+                )
 
         else:
             try:
                 status_before = self.cached_status
-            except FaultUnavailable:
+            except FaultUnavailable as e:
                 if self.error_on_missing_fault:
                     self._raise_for_faults()
                 else:
@@ -564,7 +569,10 @@ class Item:
                         node=self.node.name,
                     ))
                     status_code = self.STATUS_SKIPPED
-                    details = self.SKIP_REASON_FAULT_UNAVAILABLE
+                    details = (
+                        self.SKIP_REASON_FAULT_UNAVAILABLE,
+                        str(e),
+                    )
             else:
                 if self.cached_unless_result:
                     io.debug(_(

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -227,7 +227,7 @@ def apply_items(
             item_queue.item_ok(item)
         elif status_code == Item.STATUS_SKIPPED:
             if skipped_item_callback is not None:
-                skipped_item_callback(item.node, item, details)
+                skipped_item_callback(item.node, item, status_code, details)
             for skipped_item in item_queue.item_skipped(item):
                 skip_reason = Item.SKIP_REASON_DEP_SKIPPED
                 for lock in other_peoples_soft_locks:

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -177,6 +177,7 @@ def apply_items(
     workers=1,
     interactive=False,
     show_diff=True,
+    skipped_item_callback=None,
 ):
     item_queue = ItemQueue(node)
     # the item queue might contain new generated items (canned actions)
@@ -225,6 +226,8 @@ def apply_items(
         elif status_code == Item.STATUS_OK:
             item_queue.item_ok(item)
         elif status_code == Item.STATUS_SKIPPED:
+            if skipped_item_callback is not None:
+                skipped_item_callback(item.node, item, details)
             for skipped_item in item_queue.item_skipped(item):
                 skip_reason = Item.SKIP_REASON_DEP_SKIPPED
                 for lock in other_peoples_soft_locks:
@@ -716,6 +719,7 @@ class Node:
         show_diff=True,
         skip_list=(),
         workers=4,
+        skipped_item_callback=None,
     ):
         if not list(self.items):
             io.stdout(_("{x} {node}  has no items").format(
@@ -776,6 +780,7 @@ class Node:
                         workers=workers,
                         interactive=interactive,
                         show_diff=show_diff,
+                        skipped_item_callback=skipped_item_callback,
                     )
             except NodeLockedException as e:
                 if not interactive:

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -401,8 +401,9 @@ def format_item_result(
         details_text = ""
     elif result == Item.STATUS_SKIPPED:
         if isinstance(details, tuple):
-            details = details[0]
-        details_text = "({})".format(Item.SKIP_REASON_DESC[details])
+            details_text = "({})".format(Item.SKIP_REASON_DESC[details[0]].format(details[1]))
+        else:
+            details_text = "({})".format(Item.SKIP_REASON_DESC[details])
     else:
         details_text = "({})".format(", ".join(sorted(details[2])))
     if result == Item.STATUS_FAILED:

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -397,6 +397,8 @@ def format_item_result(
     if created or deleted or details is None:
         details_text = ""
     elif result == Item.STATUS_SKIPPED:
+        if isinstance(details, tuple):
+            details = details[0]
         details_text = "({})".format(Item.SKIP_REASON_DESC[details])
     else:
         details_text = "({})".format(", ".join(sorted(details[2])))


### PR DESCRIPTION
This fixes #514 by showing a summary of skipped items at the end for all items that provide a more detailed description of the reason they were skipped.

This was implemented by allowing an item to return a tuple for `details` in `Item.apply()`, of which the first value is the technical reason, the second value is the text message that gets shown to the user. For `FaultUnavailable`, we just show the exception message.

![screenshot_2024-05-13_053426](https://github.com/bundlewrap/bundlewrap/assets/332513/e94bab42-5dac-40d9-83f5-efed7e90aea9)
