### PR TITLE
bw lock: Don't do anything if there are no targets

### DIFF
--- a/bundlewrap/cmdline/lock.py
+++ b/bundlewrap/cmdline/lock.py
@@ -40,6 +40,9 @@ def bw_lock_add(repo, args):
     errors = []
     target_nodes = get_target_nodes(repo, args['targets'], args['node_workers'])
     target_nodes = remove_dummy_nodes(target_nodes)
+    if not target_nodes:
+        return
+
     pending_nodes = target_nodes[:]
     max_node_name_length = max([len(node.name) for node in target_nodes])
     lock_id = randstr(length=4).upper()
@@ -94,6 +97,9 @@ def bw_lock_remove(repo, args):
     errors = []
     target_nodes = get_target_nodes(repo, args['targets'], args['node_workers'])
     target_nodes = remove_dummy_nodes(target_nodes)
+    if not target_nodes:
+        return
+
     pending_nodes = target_nodes[:]
     max_node_name_length = max([len(node.name) for node in target_nodes])
     io.progress_set_total(len(pending_nodes))
@@ -150,6 +156,9 @@ def bw_lock_show(repo, args):
     errors = []
     target_nodes = get_target_nodes(repo, args['targets'], args['node_workers'])
     target_nodes = remove_dummy_nodes(target_nodes)
+    if not target_nodes:
+        return
+
     pending_nodes = target_nodes[:]
     locks_on_node = {}
     exit_code = 0


### PR DESCRIPTION
This used to crash if there were no targets whatsoever:

    $ bw lock add foo -e 1m -c test
    » foo  is a dummy node
    Traceback (most recent call last):
      File "/home/user/git/bundlewrap/bundlewrap/utils/cmdline.py", line 71, in wrapper
        return f(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^
      File "/home/user/git/bundlewrap/bundlewrap/cmdline/__init__.py", line 77, in main
        pargs.func(repo, text_pargs)
      File "/home/user/git/bundlewrap/bundlewrap/cmdline/lock.py", line 44, in bw_lock_add
        max_node_name_length = max([len(node.name) for node in target_nodes])
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ValueError: max() iterable argument is empty