### PR TITLE
Address two pip issues

### DIFF
--- a/bundlewrap/items/pkg_pip.py
+++ b/bundlewrap/items/pkg_pip.py
@@ -12,6 +12,7 @@ class PipPkg(Item):
     """
     BUNDLE_ATTRIBUTE_NAME = "pkg_pip"
     ITEM_ATTRIBUTES = {
+        'break_system_packages': False,
         'installed': True,
         'version': None,
     }
@@ -96,7 +97,14 @@ class PipPkg(Item):
         if version:
             pkgname = "{}=={}".format(pkgname, version)
         pip_path, pkgname = self._split_path(pkgname)
-        return self.run("{} install -U {}".format(quote(pip_path), quote(pkgname)), may_fail=True)
+        return self.run(
+            "{} install {} -U {}".format(
+                quote(pip_path),
+                '--break-system-packages' if self.attributes['break_system_packages'] else '',
+                quote(pkgname),
+            ),
+            may_fail=True,
+        )
 
     def _pkg_installed(self, pkgname):
         pip_path, pkgname = self._split_path(pkgname)
@@ -112,7 +120,11 @@ class PipPkg(Item):
     def _pkg_remove(self, pkgname):
         pip_path, pkgname = self._split_path(pkgname)
         return self.run(
-            "{} uninstall -y {}".format(quote(pip_path), quote(pkgname)),
+            "{} uninstall {} -y {}".format(
+                quote(pip_path),
+                '--break-system-packages' if self.attributes['break_system_packages'] else '',
+                quote(pkgname),
+            ),
             may_fail=True,
         )
 

--- a/docs/content/items/pkg_pip.md
+++ b/docs/content/items/pkg_pip.md
@@ -23,6 +23,16 @@ See also: [The list of generic builtin item attributes](../repo/items.py.md#buil
 
 <hr>
 
+## break\_system\_packages
+
+`True` if you want BundleWrap to add the `--break-system-packages` flag. Refer to <https://www.debian.org/releases/bookworm/amd64/release-notes/ch-information.en.html#python3-pep-668>.
+
+Default is `False`.
+
+This feature is *temporary* and usage is *discouraged*. It might be removed from future BundleWrap versions.
+
+<hr>
+
 ## installed
 
 `True` when the package is expected to be present on the system; `False` if it should be removed.


### PR DESCRIPTION
Adding `--break-system-packages` should be relatively uncontroversial.

Switching from `pip freeze` to `pip list` is somewhat necessary in order to make good use of `--break-system-packages` and to transition away from pip packages (see commit message). I am not sure about compatibility, though. I tested it on:

-   OpenBSD 7.5 (pip 24.0 on Python 3.10)
-   Current Arch (pip 24.0 on Python 3.12)
-   Ubuntu 20.04 (pip 20.0.2 on Python 3.8)
-   Ubuntu 22.04 (pip 22.0.2 on Python 3.10)
-   Ubuntu 24.04 (pip 24.0 on Python 3.12)

Notably: *Not* tested on Ubuntu 18.04. If we care about that version, I’ll set up a VM.
