### PR TITLE
postgres_roles: support modern hash algorithm

### DIFF
--- a/bundlewrap/items/postgres_roles.py
+++ b/bundlewrap/items/postgres_roles.py
@@ -19,7 +19,8 @@ def delete_role(node, role):
 
 def fix_role(node, role, attrs, create=False):
     if create:
-        create_sql = f"CREATE ROLE \\\"{role}\\\" WITH LOGIN {attrs['superuser']}SUPERUSER"
+        superuser_sql = "SUPERUSER" if attrs['superuser'] else "NOSUPERUSER"
+        create_sql = f"CREATE ROLE \\\"{role}\\\" WITH LOGIN {superuser_sql}"
         node.run(f"psql -nqw -c {quote(create_sql)}", user="postgres")
 
     password_sql = f"UPDATE pg_authid SET rolpassword = '{attrs['password_hash']}' WHERE rolname = '{role}'"

--- a/bundlewrap/items/postgres_roles.py
+++ b/bundlewrap/items/postgres_roles.py
@@ -1,4 +1,5 @@
 from passlib.apps import postgres_context
+from shlex import quote
 
 from bundlewrap.exceptions import BundleError
 from bundlewrap.items import Item
@@ -17,14 +18,12 @@ def delete_role(node, role):
 
 
 def fix_role(node, role, attrs, create=False):
-    password = " PASSWORD '{}'".format(attrs['password_hash'])
-    sql = "{operation} ROLE \\\"{role}\\\" WITH LOGIN {superuser}SUPERUSER{password}".format(
-        operation="CREATE" if create else "ALTER",
-        password="" if attrs['password_hash'] is None else password,
-        role=role,
-        superuser="" if attrs['superuser'] is True else "NO",
-    )
-    node.run(f"psql -nqw -c \"{sql}\"", user="postgres")
+    if create:
+        create_sql = f"CREATE ROLE \\\"{role}\\\" WITH LOGIN {attrs['superuser']}SUPERUSER"
+        node.run(f"psql -nqw -c {quote(create_sql)}", user="postgres")
+
+    password_sql = f"UPDATE pg_authid SET rolpassword = '{attrs['password_hash']}' WHERE rolname = '{role}'"
+    node.run(f"psql -nqw -c {quote(password_sql)}", user="postgres")
 
 
 def get_role(node, role):


### PR DESCRIPTION
**Problem:**
postgres_role did not accept scram sha 256, because it used CREATE and ALTER,  which does not accept anything other than md5 as hash. When passing postgres a password that starts with "md5" it thinks that it is not a password but instead a hash. Anything other that does not start with "md5", postgres trys to hash it.

**Solution:**
Splitted the function so we have one for creating the user and one for setting the password hash directly.