### PR TITLE
Remove concurrency blockers, `ItemQueue` handles this now

### DIFF
--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -735,11 +735,12 @@ will exit with code 47 if any matching items are locked
         dest='depends_auto',
         help=_("do not show auto-generated and trigger dependencies"),
     )
+    # XXX Remove in bw 5
     parser_plot_subparsers_node.add_argument(
         "--no-depends-conc",
         action='store_false',
         dest='depends_concurrency',
-        help=_("do not show concurrency blocker dependencies"),
+        help=_("obsolete and ignored"),
     )
     parser_plot_subparsers_node.add_argument(
         "--no-depends-regular",

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -705,7 +705,6 @@ will exit with code 47 if any matching items are locked
         "Color guide: "
         "needs in red, "
         "after in blue, "
-        "concurrency blockers in purple, "
         "before in yellow, "
         "needed_by in orange, "
         "auto in green, "

--- a/bundlewrap/cmdline/plot.py
+++ b/bundlewrap/cmdline/plot.py
@@ -33,7 +33,6 @@ def bw_plot_node(repo, args):
         node.name,
         prepare_dependencies(node),
         cluster=args['cluster'],
-        concurrency=args['depends_concurrency'],
         regular=args['depends_regular'],
         reverse=args['depends_reverse'],
         auto=args['depends_auto'],

--- a/bundlewrap/itemqueue.py
+++ b/bundlewrap/itemqueue.py
@@ -32,8 +32,7 @@ class ItemQueue(BaseQueue):
     def __init__(self, node):
         super().__init__(node)
 
-        # Optional sanity check. Remove this mechanism if performance is
-        # a concern.
+        # Optional sanity check.
         self.item_types_with_blockers = set()
 
     def item_failed(self, item):
@@ -93,12 +92,16 @@ class ItemQueue(BaseQueue):
         for item in self.items_without_deps:
             add_this_item = True
             for item_blocked_for in item.block_concurrent(item.node.os, item.node.os_version):
-                # Optional sanity check. Remove this mechanism if
-                # performance is a concern.
+                # Optional sanity check.
                 #
                 # Keep track of item types that have blockers. We can
                 # later use this to do a sanity check: Was there a bug
                 # and did we accidentally run blocked items after all?
+                #
+                # Note that this does NOT catch all cases that are
+                # theoretically possible. It only catches things like
+                # pkg_apt where only one item of that exact type can be
+                # running.
                 self.item_types_with_blockers.add(item.ITEM_TYPE_NAME)
 
                 if item_blocked_for in running_item_types:
@@ -126,12 +129,7 @@ class ItemQueue(BaseQueue):
 
         self.pending_items.add(item)
 
-        # Optional sanity check. Remove this mechanism if performance is
-        # a concern.
-        #
-        # Also not that this does NOT catch all cases that are
-        # theoretically possible. It only catches things like pkg_apt
-        # where only one item of that exact type can be running.
+        # Optional sanity check.
         item_types_running = defaultdict(int)
         for i in self.pending_items:
             item_types_running[i.ITEM_TYPE_NAME] += 1

--- a/bundlewrap/itemqueue.py
+++ b/bundlewrap/itemqueue.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from .deps import (
     find_item,
     prepare_dependencies,
@@ -130,12 +132,11 @@ class ItemQueue(BaseQueue):
         # Also not that this does NOT catch all cases that are
         # theoretically possible. It only catches things like pkg_apt
         # where only one item of that exact type can be running.
-        item_types_running = {}
+        item_types_running = defaultdict(int)
         for i in self.pending_items:
-            item_types_running.setdefault(i.ITEM_TYPE_NAME, 0)
             item_types_running[i.ITEM_TYPE_NAME] += 1
         for it in self.item_types_with_blockers:
-            if item_types_running.get(it, 0) > 1:
+            if item_types_running[it] > 1:
                 raise Exception(f'BUG! More than one {it} running!')
 
         return item

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -194,18 +194,6 @@ def apply_items(
 
     def next_task():
         item = item_queue.pop()
-
-        # XXX Remove and somehow turn this into a proper test case
-        item_types_running = {}
-        for i in item_queue.pending_items:
-            item_types_running.setdefault(i.ITEM_TYPE_NAME, 0)
-            item_types_running[i.ITEM_TYPE_NAME] += 1
-        if (
-            item_types_running.get('pkg_apt', 0) > 1 or
-            item_types_running.get('pkg_pip', 0) > 1
-        ):
-            raise Exception('Concurrency blocking didn’t work')
-
         return {
             'task_id': "{}:{}".format(node.name, item.id),
             'target': item.apply,

--- a/bundlewrap/utils/plot.py
+++ b/bundlewrap/utils/plot.py
@@ -94,10 +94,6 @@ def graph_for_items(
                 else:
                     yield "\"{}\" -> \"{}\" [color=\"#42AFFF\",penwidth=2]".format(item.id, dep.id)
 
-        if concurrency:
-            for dep in sorted(item._deps_concurrency & items):
-                yield "\"{}\" -> \"{}\" [color=\"#714D99\",penwidth=2]".format(item.id, dep.id)
-
         if reverse:
             # FIXME this is not filtering auto deps, but we should rethink filters anyway in 5.0
             for dep in sorted(item._deps_before & items):

--- a/bundlewrap/utils/plot.py
+++ b/bundlewrap/utils/plot.py
@@ -33,7 +33,6 @@ def graph_for_items(
     title,
     items,
     cluster=True,
-    concurrency=True,
     regular=True,
     reverse=True,
     auto=True,


### PR DESCRIPTION
Before polishing this further, I’d like to get some feedback.

We saw in #779 that injecting concurrency blockers can lead to (artificial, unintended) loops. This PR addresses that issue by getting rid of concurrency blockers altogether.

Instead, `Node::apply_items()` now keeps track of which item types are currently running. When asking for the next available item to apply, only non-conflicting items will be considered.
