### PR TITLE
pkg_dnf: adjustments for dnf5 compatibility

### DIFF
--- a/bundlewrap/items/pkg_dnf.py
+++ b/bundlewrap/items/pkg_dnf.py
@@ -15,19 +15,19 @@ class DnfPkg(Pkg):
         return ["pkg_dnf", "pkg_yum"]
 
     def pkg_all_installed(self):
-        result = self.run("dnf -d0 -e0 list installed")
+        result = self.run("dnf list --installed")
         for line in result.stdout.decode('utf-8').strip().split("\n"):
             yield "{}:{}".format(self.ITEM_TYPE_NAME, line.split()[0].split(".")[0])
 
     def pkg_install(self):
-        self.run("dnf -d0 -e0 -y install {}".format(quote(self.name)), may_fail=True)
+        self.run("dnf -y install {}".format(quote(self.name)), may_fail=True)
 
     def pkg_installed(self):
         result = self.run(
-            "dnf -d0 -e0 list installed {}".format(quote(self.name)),
+            "dnf list --installed {}".format(quote(self.name)),
             may_fail=True,
         )
         return result.return_code == 0
 
     def pkg_remove(self):
-        self.run("dnf -d0 -e0 -y remove {}".format(quote(self.name)), may_fail=True)
+        self.run("dnf -y remove {}".format(quote(self.name)), may_fail=True)


### PR DESCRIPTION
-d and -e are both deprecated[1]
"dnf list --installed" is compatible with both dnf versions

[1] https://dnf.readthedocs.io/en/latest/command_ref.html

#786 