### PR TITLE
`bw debug`: add history reading and saving

### DIFF
--- a/bundlewrap/cmdline/debug.py
+++ b/bundlewrap/cmdline/debug.py
@@ -55,9 +55,11 @@ def bw_debug(repo, args):
         # work with.
         if hasattr(readline, 'append_history_file'):
             new_history_length = readline.get_current_history_length()
+            readline.set_history_length(10000)
             readline.append_history_file(
                 new_history_length - previous_history_length,
                 history_filename,
             )
         else:
+            readline.set_history_length(10000)
             readline.write_history_file(history_filename)

--- a/bundlewrap/cmdline/debug.py
+++ b/bundlewrap/cmdline/debug.py
@@ -1,12 +1,12 @@
+import readline
 from code import interact
-from readline import set_completer, parse_and_bind
+from os.path import isfile, join
 from rlcompleter import Completer
 
 from .. import VERSION_STRING
 from ..utils.cmdline import get_node
 from ..utils.text import mark_for_translation as _
 from ..utils.ui import io
-
 
 DEBUG_BANNER = _("BundleWrap {version} interactive repository inspector\n"
                  "> You can access the current repository as 'repo'."
@@ -28,6 +28,17 @@ def bw_debug(repo, args):
     if args['command']:
         exec(args['command'], env)
     else:
-        set_completer(Completer(env).complete)
-        parse_and_bind("tab: complete")
+        # read 'bw debug' history, if it exists
+        history_filename = join(repo.path, '.bw_debug_history')
+        if isfile(history_filename):
+            readline.read_history_file(history_filename)
+
+        # set up tab completion
+        readline.set_completer(Completer(env).complete)
+        readline.parse_and_bind("tab: complete")
+
+        # launch interactive debug session
         interact(banner=banner, local=env)
+
+        # save history
+        readline.write_history_file(history_filename)


### PR DESCRIPTION
It was really annoying to create https://github.com/bundlewrap/bundlewrap/pull/732 without history