### PR TITLE
Add bash completion for targets via argcomplete

### DIFF
--- a/bundlewrap/cmdline/__init__.py
+++ b/bundlewrap/cmdline/__init__.py
@@ -1,3 +1,5 @@
+# PYTHON_ARGCOMPLETE_OK
+
 from cProfile import Profile
 from os import environ
 from os.path import abspath

--- a/bundlewrap/cmdline/generate_completions.py
+++ b/bundlewrap/cmdline/generate_completions.py
@@ -1,5 +1,8 @@
+from os.path import join
+
+
 def bw_generate_completions(repo, args):
-    compl_file = f'{repo.path}/.bw_shell_completion_targets'
+    compl_file = join(repo.path, '.bw_shell_completion_targets')
 
     targets = [node.name for node in repo.nodes]
     targets.extend([group.name for group in repo.groups])

--- a/bundlewrap/cmdline/generate_completions.py
+++ b/bundlewrap/cmdline/generate_completions.py
@@ -1,0 +1,11 @@
+def bw_generate_completions(repo, args):
+    compl_file = f'{repo.path}/.bw_shell_completion_targets'
+
+    targets = [node.name for node in repo.nodes]
+    targets.extend([group.name for group in repo.groups])
+    targets.extend([f'!group:{group.name}' for group in repo.groups])
+    targets.extend([f'bundle:{bundle}' for bundle in repo.bundle_names])
+    targets.extend([f'!bundle:{bundle}' for bundle in repo.bundle_names])
+
+    with open(compl_file, 'w') as f:
+        f.write('\n'.join(targets))

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -35,11 +35,10 @@ except ImportError:
 class TargetCompleter:
     """Completer for bw targets, which can be used by argcomplete"""
 
-    def __call__(self, prefix, **kwargs):
+    def __call__(self, parsed_args, **kwargs):
         try:
             # warn(kwargs)  # For development and debugging
-            repo_path = kwargs['parsed_args'].repo_path
-            compl_file = f'{repo_path}/.bw_shell_completion_targets'
+            compl_file = f'{parsed_args.repo_path}/.bw_shell_completion_targets'
             with open(compl_file) as f:
                 return f.read().splitlines()
         except FileNotFoundError:

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -1,6 +1,5 @@
 from argparse import ArgumentParser, RawTextHelpFormatter, SUPPRESS
 from os import environ, getcwd
-from os.path import abspath
 
 from .. import VERSION_STRING
 from ..utils.cmdline import HELP_get_target_nodes
@@ -38,7 +37,8 @@ class TargetCompleter:
 
     def __call__(self, prefix, **kwargs):
         try:
-            repo_path = abspath(environ.get('BW_REPO_PATH', getcwd()))
+            # warn(kwargs)  # For development and debugging
+            repo_path = kwargs['parsed_args'].repo_path
             compl_file = f'{repo_path}/.bw_shell_completion_targets'
             with open(compl_file) as f:
                 return f.read().splitlines()

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -23,6 +23,25 @@ from .test import bw_test
 from .verify import bw_verify
 from .zen import bw_zen
 
+try:
+    from argcomplete import autocomplete
+
+    bash_completion = True
+except ImportError:
+    bash_completion = False
+
+
+class TargetCompleter:
+    """Completer for bw targets, which can be used by argcomplete"""
+
+    def __call__(self, prefix, **kwargs):
+        compl_file = environ.get('BW_TARGET_COMPLETION_FILE')
+        try:
+            with open(compl_file) as f:
+                return f.read().split('\n')
+        except Exception:
+            return []
+
 
 def build_parser_bw():
     parser = ArgumentParser(
@@ -83,13 +102,16 @@ def build_parser_bw():
         formatter_class=RawTextHelpFormatter,  # for HELP_get_target_nodes
     )
     parser_apply.set_defaults(func=bw_apply)
-    parser_apply.add_argument(
+    targets_apply = parser_apply.add_argument(
         'targets',
         metavar=_("TARGET"),
         nargs='+',
         type=str,
         help=HELP_get_target_nodes,
     )
+    if bash_completion:
+        targets_apply.completer = TargetCompleter()
+
     parser_apply.add_argument(
         "-D",
         "--no-diff",
@@ -281,13 +303,15 @@ bundle:my_bundle  # items in this bundle
         dest='metadata',
         help=_("compare metadata instead of configuration"),
     )
-    parser_diff.add_argument(
+    targets_diff = parser_diff.add_argument(
         'targets',
         metavar=_("TARGET"),
         nargs='+',
         type=str,
         help=HELP_get_target_nodes,
     )
+    if bash_completion:
+        targets_diff.completer = TargetCompleter()
 
     # bw groups
     help_groups = _("Lists groups in this repository")
@@ -370,13 +394,16 @@ bundle:my_bundle  # items in this bundle
         formatter_class=RawTextHelpFormatter,  # for HELP_get_target_nodes
     )
     parser_ipmi.set_defaults(func=bw_ipmi)
-    parser_ipmi.add_argument(
+    targets_ipmi = parser_ipmi.add_argument(
         'targets',
         metavar=_("TARGET"),
         nargs='+',
         type=str,
         help=HELP_get_target_nodes,
     )
+    if bash_completion:
+        targets_ipmi.completer = TargetCompleter()
+
     parser_ipmi.add_argument(
         'command',
         metavar=_("COMMAND"),
@@ -473,13 +500,16 @@ bundle:my_bundle  # items in this bundle
         formatter_class=RawTextHelpFormatter,  # for HELP_get_target_nodes
     )
     parser_lock_add.set_defaults(func=bw_lock_add)
-    parser_lock_add.add_argument(
+    targets_lock_add = parser_lock_add.add_argument(
         'targets',
         metavar=_("TARGET"),
         nargs='+',
         type=str,
         help=HELP_get_target_nodes,
     )
+    if bash_completion:
+        targets_lock_add.completer = TargetCompleter()
+
     parser_lock_add.add_argument(
         "-c",
         "--comment",
@@ -533,13 +563,16 @@ bundle:my_bundle  # items in this bundle
         formatter_class=RawTextHelpFormatter,  # for HELP_get_target_nodes
     )
     parser_lock_remove.set_defaults(func=bw_lock_remove)
-    parser_lock_remove.add_argument(
+    targets_lock_remove = parser_lock_remove.add_argument(
         'targets',
         metavar=_("TARGET"),
         nargs='+',
         type=str,
         help=HELP_get_target_nodes,
     )
+    if bash_completion:
+        targets_lock_remove.completer = TargetCompleter()
+
     parser_lock_remove.add_argument(
         'lock_id',
         metavar=_("LOCK_ID"),
@@ -566,13 +599,16 @@ bundle:my_bundle  # items in this bundle
         formatter_class=RawTextHelpFormatter,  # for HELP_get_target_nodes
     )
     parser_lock_show.set_defaults(func=bw_lock_show)
-    parser_lock_show.add_argument(
+    targets_lock_show = parser_lock_show.add_argument(
         'targets',
         metavar=_("TARGETS"),
         nargs='+',
         type=str,
         help=HELP_get_target_nodes,
     )
+    if bash_completion:
+        targets_lock_show.completer = TargetCompleter()
+
     parser_lock_show.add_argument(
         "-i",
         "--items",
@@ -602,7 +638,8 @@ will exit with code 47 if any matching items are locked
     )
 
     # bw metadata
-    help_metadata = ("View a JSON representation of a node's metadata (defaults blue, reactors green, groups yellow, node red, uncolored if mixed-source) or a table of selected metadata keys from multiple nodes")
+    help_metadata = (
+        "View a JSON representation of a node's metadata (defaults blue, reactors green, groups yellow, node red, uncolored if mixed-source) or a table of selected metadata keys from multiple nodes")
     parser_metadata = subparsers.add_parser(
         "metadata",
         description=help_metadata,
@@ -610,13 +647,16 @@ will exit with code 47 if any matching items are locked
         formatter_class=RawTextHelpFormatter,
     )
     parser_metadata.set_defaults(func=bw_metadata)
-    parser_metadata.add_argument(
+    targets_metadata = parser_metadata.add_argument(
         'targets',
         metavar=_("TARGET"),
         nargs='+',
         type=str,
         help=HELP_get_target_nodes,
     )
+    if bash_completion:
+        targets_metadata.completer = TargetCompleter()
+
     parser_metadata.add_argument(
         "-k", "--keys",
         default=[],
@@ -624,7 +664,8 @@ will exit with code 47 if any matching items are locked
         metavar=_("KEY"),
         nargs='*',
         type=str,
-        help=_("show only partial metadata from the given key paths (e.g. `bw metadata mynode -k users/jdoe` to show `mynode.metadata['users']['jdoe']`)"),
+        help=_(
+            "show only partial metadata from the given key paths (e.g. `bw metadata mynode -k users/jdoe` to show `mynode.metadata['users']['jdoe']`)"),
     )
     parser_metadata.add_argument(
         "-b", "--blame",
@@ -700,7 +741,7 @@ will exit with code 47 if any matching items are locked
                "(defaults to {})").format(bw_nodes_p_default),
         type=int,
     )
-    parser_nodes.add_argument(
+    targets_nodes = parser_nodes.add_argument(
         'targets',
         default=None,
         metavar=_("TARGET"),
@@ -708,6 +749,8 @@ will exit with code 47 if any matching items are locked
         type=str,
         help=HELP_get_target_nodes,
     )
+    if bash_completion:
+        targets_nodes.completer = TargetCompleter()
 
     # bw plot
     help_plot = _("Generates DOT output that can be piped into `dot -Tsvg -ooutput.svg`. "
@@ -953,13 +996,16 @@ will exit with code 47 if any matching items are locked
         formatter_class=RawTextHelpFormatter,  # for HELP_get_target_nodes
     )
     parser_run.set_defaults(func=bw_run)
-    parser_run.add_argument(
+    targets_run = parser_run.add_argument(
         'targets',
         metavar=_("TARGET"),
         nargs='+',
         type=str,
         help=HELP_get_target_nodes,
     )
+    if bash_completion:
+        targets_run.completer = TargetCompleter()
+
     parser_run.add_argument(
         'command',
         metavar=_("COMMAND"),
@@ -1029,7 +1075,7 @@ will exit with code 47 if any matching items are locked
         formatter_class=RawTextHelpFormatter,  # for HELP_get_target_nodes
     )
     parser_test.set_defaults(func=bw_test)
-    parser_test.add_argument(
+    targets_test = parser_test.add_argument(
         'targets',
         default=None,
         metavar=_("TARGET"),
@@ -1037,6 +1083,9 @@ will exit with code 47 if any matching items are locked
         type=str,
         help=HELP_get_target_nodes + _("\n(defaults to all)"),
     )
+    if bash_completion:
+        targets_test.completer = TargetCompleter()
+
     parser_test.add_argument(
         "-d",
         "--config-determinism",
@@ -1144,13 +1193,16 @@ will exit with code 47 if any matching items are locked
         formatter_class=RawTextHelpFormatter,  # for HELP_get_target_nodes
     )
     parser_verify.set_defaults(func=bw_verify)
-    parser_verify.add_argument(
+    targets_verify = parser_verify.add_argument(
         'targets',
         metavar=_("TARGET"),
         nargs='+',
         type=str,
         help=HELP_get_target_nodes,
     )
+    if bash_completion:
+        targets_verify.completer = TargetCompleter()
+
     parser_verify.add_argument(
         "-a",
         "--show-all",
@@ -1227,4 +1279,7 @@ bundle:my_bundle  # items in this bundle
     # bw zen
     parser_zen = subparsers.add_parser("zen")
     parser_zen.set_defaults(func=bw_zen)
+
+    if bash_completion:
+        autocomplete(parser)
     return parser

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -8,6 +8,7 @@ from ..utils.text import mark_for_translation as _
 from .apply import bw_apply
 from .debug import bw_debug
 from .diff import bw_diff
+from .generate_completions import bw_generate_completions
 from .groups import bw_groups
 from .hash import bw_hash
 from .ipmi import bw_ipmi
@@ -1286,5 +1287,14 @@ bundle:my_bundle  # items in this bundle
     parser_zen.set_defaults(func=bw_zen)
 
     if shell_completion:
+        # bw generate_completions
+        help_generate_completions = _("Generates the shell completion file")
+        parser_apply = subparsers.add_parser(
+            "generate_completions",
+            description=help_generate_completions,
+            help=help_generate_completions,
+        )
+        parser_apply.set_defaults(func=bw_generate_completions)
+
         autocomplete(parser)
     return parser

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -1289,12 +1289,12 @@ bundle:my_bundle  # items in this bundle
     if shell_completion:
         # bw generate_completions
         help_generate_completions = _("Generates the shell completion file")
-        parser_apply = subparsers.add_parser(
+        parser_generate_completions = subparsers.add_parser(
             "generate_completions",
             description=help_generate_completions,
             help=help_generate_completions,
         )
-        parser_apply.set_defaults(func=bw_generate_completions)
+        parser_generate_completions.set_defaults(func=bw_generate_completions)
 
         autocomplete(parser)
     return parser

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser, RawTextHelpFormatter, SUPPRESS
 from os import environ, getcwd
+from os.path import abspath
 
 from .. import VERSION_STRING
 from ..utils.cmdline import HELP_get_target_nodes
@@ -24,7 +25,7 @@ from .verify import bw_verify
 from .zen import bw_zen
 
 try:
-    from argcomplete import autocomplete
+    from argcomplete import autocomplete, warn
 
     shell_completion = True
 except ImportError:
@@ -35,11 +36,15 @@ class TargetCompleter:
     """Completer for bw targets, which can be used by argcomplete"""
 
     def __call__(self, prefix, **kwargs):
-        compl_file = environ.get('BW_TARGET_COMPLETION_FILE')
         try:
+            repo_path = abspath(environ.get('BW_REPO_PATH', getcwd()))
+            compl_file = f'{repo_path}/.bw_shell_completion_targets'
             with open(compl_file) as f:
                 return f.read().splitlines()
-        except Exception:
+        except FileNotFoundError:
+            return []
+        except Exception as exc:
+            warn(f'Reading from target completion file failed: {repr(exc)}')
             return []
 
 

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -26,9 +26,9 @@ from .zen import bw_zen
 try:
     from argcomplete import autocomplete
 
-    bash_completion = True
+    shell_completion = True
 except ImportError:
-    bash_completion = False
+    shell_completion = False
 
 
 class TargetCompleter:
@@ -38,7 +38,7 @@ class TargetCompleter:
         compl_file = environ.get('BW_TARGET_COMPLETION_FILE')
         try:
             with open(compl_file) as f:
-                return f.read().split('\n')
+                return f.read().splitlines()
         except Exception:
             return []
 
@@ -109,7 +109,7 @@ def build_parser_bw():
         type=str,
         help=HELP_get_target_nodes,
     )
-    if bash_completion:
+    if shell_completion:
         targets_apply.completer = TargetCompleter()
 
     parser_apply.add_argument(
@@ -310,7 +310,7 @@ bundle:my_bundle  # items in this bundle
         type=str,
         help=HELP_get_target_nodes,
     )
-    if bash_completion:
+    if shell_completion:
         targets_diff.completer = TargetCompleter()
 
     # bw groups
@@ -401,7 +401,7 @@ bundle:my_bundle  # items in this bundle
         type=str,
         help=HELP_get_target_nodes,
     )
-    if bash_completion:
+    if shell_completion:
         targets_ipmi.completer = TargetCompleter()
 
     parser_ipmi.add_argument(
@@ -507,7 +507,7 @@ bundle:my_bundle  # items in this bundle
         type=str,
         help=HELP_get_target_nodes,
     )
-    if bash_completion:
+    if shell_completion:
         targets_lock_add.completer = TargetCompleter()
 
     parser_lock_add.add_argument(
@@ -570,7 +570,7 @@ bundle:my_bundle  # items in this bundle
         type=str,
         help=HELP_get_target_nodes,
     )
-    if bash_completion:
+    if shell_completion:
         targets_lock_remove.completer = TargetCompleter()
 
     parser_lock_remove.add_argument(
@@ -606,7 +606,7 @@ bundle:my_bundle  # items in this bundle
         type=str,
         help=HELP_get_target_nodes,
     )
-    if bash_completion:
+    if shell_completion:
         targets_lock_show.completer = TargetCompleter()
 
     parser_lock_show.add_argument(
@@ -654,7 +654,7 @@ will exit with code 47 if any matching items are locked
         type=str,
         help=HELP_get_target_nodes,
     )
-    if bash_completion:
+    if shell_completion:
         targets_metadata.completer = TargetCompleter()
 
     parser_metadata.add_argument(
@@ -749,7 +749,7 @@ will exit with code 47 if any matching items are locked
         type=str,
         help=HELP_get_target_nodes,
     )
-    if bash_completion:
+    if shell_completion:
         targets_nodes.completer = TargetCompleter()
 
     # bw plot
@@ -1003,7 +1003,7 @@ will exit with code 47 if any matching items are locked
         type=str,
         help=HELP_get_target_nodes,
     )
-    if bash_completion:
+    if shell_completion:
         targets_run.completer = TargetCompleter()
 
     parser_run.add_argument(
@@ -1083,7 +1083,7 @@ will exit with code 47 if any matching items are locked
         type=str,
         help=HELP_get_target_nodes + _("\n(defaults to all)"),
     )
-    if bash_completion:
+    if shell_completion:
         targets_test.completer = TargetCompleter()
 
     parser_test.add_argument(
@@ -1200,7 +1200,7 @@ will exit with code 47 if any matching items are locked
         type=str,
         help=HELP_get_target_nodes,
     )
-    if bash_completion:
+    if shell_completion:
         targets_verify.completer = TargetCompleter()
 
     parser_verify.add_argument(
@@ -1280,6 +1280,6 @@ bundle:my_bundle  # items in this bundle
     parser_zen = subparsers.add_parser("zen")
     parser_zen.set_defaults(func=bw_zen)
 
-    if bash_completion:
+    if shell_completion:
         autocomplete(parser)
     return parser

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser, RawTextHelpFormatter, SUPPRESS
 from os import environ, getcwd
+from os.path import join
 
 from .. import VERSION_STRING
 from ..utils.cmdline import HELP_get_target_nodes
@@ -38,7 +39,7 @@ class TargetCompleter:
     def __call__(self, parsed_args, **kwargs):
         try:
             # warn(kwargs)  # For development and debugging
-            compl_file = f'{parsed_args.repo_path}/.bw_shell_completion_targets'
+            compl_file = join(parsed_args.repo_path, '.bw_shell_completion_targets')
             with open(compl_file) as f:
                 return f.read().splitlines()
         except FileNotFoundError:


### PR DESCRIPTION
The idea is to generate the possible targets asynchron and store them to a file to speed up the completion itself.
This PR contains (so far) only the changes needed in the bundlewrap parser for the completion.

Maybe we could also integrate a script/option to generate this file, but I am not sure about an good "location" for this.
Also documentation containing the dependency to argcomplete and its configuration is missing yet.

Feel free to share your thoughts and suggestions :)