### PR TITLE
bw lock show: add quiet mode

### DIFF
--- a/bundlewrap/cmdline/lock.py
+++ b/bundlewrap/cmdline/lock.py
@@ -200,7 +200,7 @@ def bw_lock_show(repo, args):
         locks_on_node,
         items=args['items'],
         repo=repo,
-        hide_nodes_without_locks=args['quiet']
+        hide_nodes_without_locks=args['hide-not-locked']
     )
     page_lines(output)
     error_summary(errors)

--- a/bundlewrap/cmdline/lock.py
+++ b/bundlewrap/cmdline/lock.py
@@ -200,6 +200,7 @@ def bw_lock_show(repo, args):
         locks_on_node,
         items=args['items'],
         repo=repo,
+        hide_nodes_without_locks=args['quiet']
     )
     page_lines(output)
     error_summary(errors)

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -607,8 +607,7 @@ will exit with code 47 if any matching items are locked
         type=int,
     )
     parser_lock_show.add_argument(
-        "-q",
-        "--quiet",
+        "--hide-not-locked",
         help=_("hide table rows for nodes without any locks "
                "(defaults to False)"),
         action='store_true',

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -606,6 +606,13 @@ will exit with code 47 if any matching items are locked
                "(defaults to {})").format(bw_lock_show_p_default),
         type=int,
     )
+    parser_lock_show.add_argument(
+        "-q",
+        "--quiet",
+        help=_("hide table rows for nodes without any locks "
+               "(defaults to False)"),
+        action='store_true',
+    )
 
     # bw metadata
     help_metadata = ("View a JSON representation of a node's metadata (defaults blue, reactors green, groups yellow, node red, uncolored if mixed-source) or a table of selected metadata keys from multiple nodes")

--- a/bundlewrap/lock.py
+++ b/bundlewrap/lock.py
@@ -286,7 +286,7 @@ def softlock_remove(node, lock_id):
     node.repo.hooks.lock_remove(node.repo, node, lock_id)
 
 
-def softlocks_to_table(locks_on_node, items=None, repo=None):
+def softlocks_to_table(locks_on_node, items=None, repo=None, hide_nodes_without_locks=False):
     rows = [[
         bold(_("node")),
         bold(_("ID")),
@@ -318,18 +318,19 @@ def softlocks_to_table(locks_on_node, items=None, repo=None):
                     first_item = environ.get("BW_TABLE_STYLE") == 'grep'
                 # always repeat for grep style
                 first_lock = environ.get("BW_TABLE_STYLE") == 'grep'
+            rows.append(ROW_SEPARATOR)
         else:
-            rows.append([
-                node_name,
-                _("(none)"),
-                "",
-                "",
-                "",
-                "",
-                "",
-            ])
-
-        rows.append(ROW_SEPARATOR)
+            if not hide_nodes_without_locks:
+                rows.append([
+                    node_name,
+                    _("(none)"),
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                ])
+                rows.append(ROW_SEPARATOR)
 
     output = list(render_table(
         rows[:-1],  # remove trailing ROW_SEPARATOR


### PR DESCRIPTION
This PR adds a new flag to `bw lock show`, allowing to hide empty lines of nodes which don't have any locks.