### PR TITLE
IOManager: fix __exit__

### DIFF
--- a/bundlewrap/utils/ui.py
+++ b/bundlewrap/utils/ui.py
@@ -222,7 +222,7 @@ class IOManager:
         # return self, so users could also do `with IOManager() as io:`
         return self
 
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         self.deactivate()
 
     def activate(self):


### PR DESCRIPTION
Turns out, you should actually read the documentation and not just commit stuff that seems to work ... (re #811 )