### PR TITLE
utils.cmdline: fix trailing comma for HELP_ vars

### DIFF
--- a/bundlewrap/utils/cmdline.py
+++ b/bundlewrap/utils/cmdline.py
@@ -144,9 +144,9 @@ bundle:my_bundle   # all nodes with this bundle
 "lambda:node.metadata_get('foo/magic', 47) < 3"
                    # all nodes whose metadata["foo"]["magic"] is less than three
 """)
-HELP_item_workers = _("number of items to apply simultaneously on each node (defaults to {})").format(DEFAULT_item_workers),
-HELP_node_workers = _("number of nodes to apply to simultaneously (defaults to {})").format(DEFAULT_node_workers),
-HELP_softlock_expiry = _("how long before the lock is ignored and removed automatically (defaults to \"{}\")").format(DEFAULT_softlock_expiry),
+HELP_item_workers = _("number of items to apply simultaneously on each node (defaults to {})").format(DEFAULT_item_workers)
+HELP_node_workers = _("number of nodes to apply to simultaneously (defaults to {})").format(DEFAULT_node_workers)
+HELP_softlock_expiry = _("how long before the lock is ignored and removed automatically (defaults to \"{}\")").format(DEFAULT_softlock_expiry)
 
 
 def _parallel_node_eval(


### PR DESCRIPTION
I broke this here: https://github.com/bundlewrap/bundlewrap/pull/808/files#diff-877d04f8faf13b17b13c7dac7cbac14ce62fcbb69a75ea7ad6f05c53be07570cR147-R149

fixes #822 822