### PR TITLE
cmdline/parser,generate_completions: Add prefix for nodes and groups

### DIFF
--- a/bundlewrap/cmdline/generate_completions.py
+++ b/bundlewrap/cmdline/generate_completions.py
@@ -4,8 +4,8 @@ from os.path import join
 def bw_generate_completions(repo, args):
     compl_file = join(repo.path, '.bw_shell_completion_targets')
 
-    targets = [node.name for node in repo.nodes]
-    targets.extend([group.name for group in repo.groups])
+    targets = [f'node:{node.name}' for node in repo.nodes]
+    targets.extend([f'group:{group.name}' for group in repo.groups])
     targets.extend([f'!group:{group.name}' for group in repo.groups])
     targets.extend([f'bundle:{bundle}' for bundle in repo.bundle_names])
     targets.extend([f'!bundle:{bundle}' for bundle in repo.bundle_names])

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -8,6 +8,7 @@ from ..utils.cmdline import (DEFAULT_item_workers, DEFAULT_node_workers,
                              HELP_item_workers, HELP_node_workers,
                              HELP_softlock_expiry)
 from ..utils.text import mark_for_translation as _
+from ..utils.text import remove_prefix
 from .apply import bw_apply
 from .debug import bw_debug
 from .diff import bw_diff
@@ -44,7 +45,10 @@ class TargetCompleter:
             # warn(kwargs)  # For development and debugging
             compl_file = join(parsed_args.repo_path, '.bw_shell_completion_targets')
             with open(compl_file) as f:
-                return f.read().splitlines()
+                return [
+                    remove_prefix(remove_prefix(line, 'node:'), 'group:')
+                    for line in f.read().splitlines()
+                ]
         except FileNotFoundError:
             return []
         except Exception as exc:

--- a/bundlewrap/utils/text.py
+++ b/bundlewrap/utils/text.py
@@ -153,6 +153,12 @@ def prefix_lines(lines, prefix):
     return output
 
 
+def remove_prefix(text, prefix):
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text
+
+
 def randstr(length=24):
     """
     Returns a random alphanumeric string of the given length.


### PR DESCRIPTION
For shell completions in scripts or other tools you might need only nodes or groups as completion.
This allows to differentiate between nodes and groups in the generated target file.
