### PR TITLE
shell completion fixups

### DIFF
--- a/bundlewrap/cmdline/generate_completions.py
+++ b/bundlewrap/cmdline/generate_completions.py
@@ -4,11 +4,11 @@ from os.path import join
 def bw_generate_completions(repo, args):
     compl_file = join(repo.path, '.bw_shell_completion_targets')
 
-    targets = [f'node:{node.name}' for node in repo.nodes]
-    targets.extend([f'group:{group.name}' for group in repo.groups])
-    targets.extend([f'!group:{group.name}' for group in repo.groups])
-    targets.extend([f'bundle:{bundle}' for bundle in repo.bundle_names])
-    targets.extend([f'!bundle:{bundle}' for bundle in repo.bundle_names])
+    targets = {f'node:{node.name}' for node in repo.nodes}
+    targets |= {f'group:{group.name}' for group in repo.groups}
+    targets |= {f'!group:{group.name}' for group in repo.groups}
+    targets |= {f'bundle:{bundle}' for bundle in repo.bundle_names}
+    targets |= {f'!bundle:{bundle}' for bundle in repo.bundle_names}
 
     with open(compl_file, 'w') as f:
-        f.write('\n'.join(targets))
+        f.write('\n'.join(sorted(targets)))

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -322,6 +322,16 @@ bundle:my_bundle  # items in this bundle
     if shell_completion:
         targets_diff.completer = TargetCompleter()
 
+    if shell_completion:
+        # bw generate-completions
+        help_generate_completions = _("Generates the shell completion file")
+        parser_generate_completions = subparsers.add_parser(
+            "generate-completions",
+            description=help_generate_completions,
+            help=help_generate_completions,
+        )
+        parser_generate_completions.set_defaults(func=bw_generate_completions)
+
     # bw groups
     help_groups = _("Lists groups in this repository")
     parser_groups = subparsers.add_parser("groups", description=help_groups, help=help_groups)
@@ -1284,14 +1294,6 @@ bundle:my_bundle  # items in this bundle
     parser_zen.set_defaults(func=bw_zen)
 
     if shell_completion:
-        # bw generate_completions
-        help_generate_completions = _("Generates the shell completion file")
-        parser_generate_completions = subparsers.add_parser(
-            "generate-completions",
-            description=help_generate_completions,
-            help=help_generate_completions,
-        )
-        parser_generate_completions.set_defaults(func=bw_generate_completions)
-
         autocomplete(parser)
+
     return parser

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -1287,7 +1287,7 @@ bundle:my_bundle  # items in this bundle
         # bw generate_completions
         help_generate_completions = _("Generates the shell completion file")
         parser_generate_completions = subparsers.add_parser(
-            "generate_completions",
+            "generate-completions",
             description=help_generate_completions,
             help=help_generate_completions,
         )


### PR DESCRIPTION
fixes #833 

* 1cf11c5e - move `bw generate-completions` to correct position in parser - Franziska Kunsmann
* 286b5403 - rename `bw generate_completions` to `generate-completions` - Franziska Kunsmann
* 7c4b0607 - cmdline.generate_completions: ensure file is sorted - Franziska Kunsmann