### PR TITLE
routeros: ignore 'dynamic' keyword during creation of new ressources

### DIFF
--- a/bundlewrap/items/routeros.py
+++ b/bundlewrap/items/routeros.py
@@ -174,7 +174,7 @@ class RouterOS(Item):
     def _add(self, command, kwargs):
         kwargs |= self.parse_identifier(self.identifier)
         command += "/add"
-        arguments = [f"={key}={value}" for key, value in kwargs.items()]
+        arguments = [f"={key}={value}" for key, value in kwargs.items() if key != "dynamic"]
         self.run_routeros(command, *arguments)
 
     def _list(self, command):


### PR DESCRIPTION
Setting items with an explicit `dynamic=no` filter worked as intended when the ressources already exist, but when new ones were created the `dynamic=no` flag was also being set, which resulted in error messages as it's not a configurable option.

An example on where this might fail:

```
        routeros[f"/interface/bridge/vlan?vlan-ids={conf['id']}&dynamic=no"] = {
            'bridge': 'bridge',
            'untagged': sorted(conf['untagged']),
            'tagged': sorted(conf['tagged']),
            [...]
        }
```

The filter is necessary so bundlewrap doesn't try to update dynamic ressources on the system, but at the same time it results in an error when ressources didn't previously exist.

This pull-requests just filters out the `dynamic` keyword from the options sent to the API during creation of new ressources.
Afaik there are no cases where dynamic is actually a valid option to be set.