### PR TITLE
Add support for numeric UIDs/GIDs for files and directories

### DIFF
--- a/bundlewrap/items/directories.py
+++ b/bundlewrap/items/directories.py
@@ -242,6 +242,8 @@ class Directory(Item):
         return {'needs': deps}
 
     def sdict(self):
+        use_uid = self.attributes['owner'] is not None and self.attributes['owner'].startswith('+')
+        use_gid = self.attributes['group'] is not None and self.attributes['group'].startswith('+')
         path_info = PathInfo(self.node, self.name)
         if not path_info.exists:
             return None
@@ -252,8 +254,8 @@ class Directory(Item):
             return {
                 'type': 'directory' if path_info.is_directory else path_info.stat['type'],
                 'mode': path_info.mode,
-                'owner': path_info.owner,
-                'group': path_info.group,
+                'owner': ('+' + path_info.owner_id) if use_uid else path_info.owner,
+                'group': ('+' + path_info.group_id) if use_gid else path_info.group,
                 'paths_to_purge': paths_to_purge,
             }
 

--- a/bundlewrap/items/files.py
+++ b/bundlewrap/items/files.py
@@ -441,6 +441,8 @@ class File(Item):
         return deps
 
     def sdict(self):
+        use_uid = self.attributes['owner'] is not None and self.attributes['owner'].startswith('+')
+        use_gid = self.attributes['group'] is not None and self.attributes['group'].startswith('+')
         path_info = PathInfo(self.node, self.name)
         if not path_info.exists:
             return None
@@ -449,8 +451,8 @@ class File(Item):
                 'type': 'file' if path_info.is_file else path_info.stat['type'],
                 'content_hash': path_info.sha1 if path_info.is_file else None,
                 'mode': path_info.mode,
-                'owner': path_info.owner,
-                'group': path_info.group,
+                'owner': ('+' + path_info.owner_id) if use_uid else path_info.owner,
+                'group': ('+' + path_info.group_id) if use_gid else path_info.group,
                 'size': path_info.size,
             }
 

--- a/docs/content/items/file.md
+++ b/docs/content/items/file.md
@@ -70,7 +70,7 @@ Encoding of the target file. Note that this applies to the remote file only, you
 
 ## group
 
-Name of the group this file belongs to. Defaults to `'root'`. Set to `None` if you don't want BundleWrap to change whatever is set on the node. If `group` is set to `None` and the file does not exist yet, `group` will be the primary group of the ssh user.
+Name of the group this file belongs to. Prefix with `+` if you want to use a GID instead of a group name (e. g. `+1234`). Defaults to `'root'`. Set to `None` if you don't want BundleWrap to change whatever is set on the node. If `group` is set to `None` and the file does not exist yet, `group` will be the primary group of the ssh user.
 
 <hr>
 
@@ -82,7 +82,7 @@ File mode as returned by `stat -c %a <file>`. Defaults to `644`. Set to `None` i
 
 ## owner
 
-Username of the file's owner. Defaults to `'root'`. Set to `None` if you don't want BundleWrap to change whatever is set on the node.  If `owner` is set to `None` and the file does not exist yet, `owner` will be the ssh user.
+Username of the file's owner. Prefix with `+` if you want to use a UID instead of a username (e. g. `+1234`). Defaults to `'root'`. Set to `None` if you don't want BundleWrap to change whatever is set on the node.  If `owner` is set to `None` and the file does not exist yet, `owner` will be the ssh user.
 
 <hr>
 


### PR DESCRIPTION
There are cases where it's necessary to use chown with a UID/GID instead
of a username because the ID of the owner/group isn't present in /etc/passwd.
This could be because the file is inside a NFS-shared directory or
because it's bind-mounted into a (uidmapped) container environment.

Currently, when using a UID instead of a username, the chown works because
it recognizes the value as ID but then afterwards the verify fails to
verify its action because it compares the output of `stat -c '%U'` with
the `owner` attribute of the File item and `stat` outputs `UNKNOWN` for
UIDs/GIDs it can't map back to a username.

To solve this, support for letting files be owned by a UID/GID instead of
a username is added in form of UIDs/GIDs prefixed by a `+` and if so,
use `stat -c '%u'` for validation to check against the UID instead of the
username.
The +-Syntax is directly taken from `chown` (both BSD and GNU) and therefore
the fix-part just works and only the sdict/check function needs to be adjusted.

Fixes #841