### PR TITLE
files: Follow redirects in `check_download()`

### DIFF
--- a/bundlewrap/items/files.py
+++ b/bundlewrap/items/files.py
@@ -39,7 +39,7 @@ DIFF_MAX_FILE_SIZE = 1024 * 1024 * 5  # bytes
 @cache
 def check_download(url, timeout):
     try:
-        head(url, timeout=timeout).raise_for_status()
+        head(url, allow_redirects=True, timeout=timeout).raise_for_status()
     except Exception as exc:
         return exc
     else:


### PR DESCRIPTION
Suppose a URL responds with something like HTTP 301. That is enough to satisfy `raise_for_status()`. But this doesn't check whether the resource *after* the redirect actually exists. This can result in successful runs of `bw test` and then `bw apply` fails.

Closes #835.