### PR TITLE
Repository.is_repo(): we need a `bundles` directory as well

### DIFF
--- a/bundlewrap/repo.py
+++ b/bundlewrap/repo.py
@@ -299,6 +299,7 @@ class Repository(MetadataGenerator):
             assert isdir(path)
             assert isfile(join(path, "nodes.py"))
             assert isfile(join(path, "groups.py"))
+            assert isdir(join(path, "bundles"))
         except AssertionError:
             return False
         return True


### PR DESCRIPTION
This fixes #866