### PR TITLE
removed --no-depends-reverse option for bw plot and use dashed lines for before and needed_by items

### DIFF
--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -849,13 +849,7 @@ will exit with code 47 if any matching items are locked
         dest='depends_regular',
         help=_("do not show after/needs dependencies"),
     )
-    parser_plot_subparsers_node.add_argument(
-        "--no-depends-reverse",
-        action='store_false',
-        dest='depends_reverse',
-        help=_("do not show before/needed_by dependencies"),
-    )
-
+   
     # bw plot groups-for-node
     help_plot_node_groups = _("Show where a specific node gets its groups from")
     parser_plot_subparsers_node_groups = parser_plot_subparsers.add_parser(

--- a/bundlewrap/cmdline/plot.py
+++ b/bundlewrap/cmdline/plot.py
@@ -34,7 +34,6 @@ def bw_plot_node(repo, args):
         prepare_dependencies(node),
         cluster=args['cluster'],
         regular=args['depends_regular'],
-        reverse=args['depends_reverse'],
         auto=args['depends_auto'],
     ):
         io.stdout(line)

--- a/bundlewrap/utils/plot.py
+++ b/bundlewrap/utils/plot.py
@@ -34,7 +34,6 @@ def graph_for_items(
     items,
     cluster=True,
     regular=True,
-    reverse=True,
     auto=True,
 ):
     items = set(items)
@@ -93,12 +92,10 @@ def graph_for_items(
                 else:
                     yield "\"{}\" -> \"{}\" [color=\"#42AFFF\",penwidth=2]".format(item.id, dep.id)
 
-        if reverse:
-            # FIXME this is not filtering auto deps, but we should rethink filters anyway in 5.0
-            for dep in sorted(item._deps_before & items):
-                yield "\"{}\" -> \"{}\" [color=\"#D1CF52\",penwidth=2]".format(item.id, dep.id)
-            for dep in sorted(item._deps_needed_by & items):
-                yield "\"{}\" -> \"{}\" [color=\"#D18C57\",penwidth=2]".format(item.id, dep.id)
+        for dep in sorted(item._deps_before & items):
+            yield "\"{}\" -> \"{}\" [color=\"#D1CF52\",penwidth=1,style=\"dashed\"]".format(item.id, dep.id)
+        for dep in sorted(item._deps_needed_by & items):
+            yield "\"{}\" -> \"{}\" [color=\"#D18C57\",penwidth=1,style=\"dashed\"]".format(item.id, dep.id)
 
         if auto:
             for dep in sorted(item._deps_triggers & items):


### PR DESCRIPTION
fixes #610 