### PR TITLE
docs/dev_item.md: Add `get_auto_attrs()`

### DIFF
--- a/docs/content/guide/dev_item.md
+++ b/docs/content/guide/dev_item.md
@@ -112,6 +112,22 @@ Create a new file called `/your/bundlewrap/repo/items/foo.py`. You can use this 
             """
             raise NotImplementedError
 
+        def get_auto_attrs(self, items):
+            """
+            Return a dict with any number of attributes. The respective
+            sets will be merged with the user-supplied values. For example:
+
+                return {
+                    'needs': {
+                        'file:/foo',
+                    },
+                }
+
+            Note that only attributes from ALLOWED_ITEM_AUTO_ATTRIBUTES are
+            allowed (see BundleWrap source code).
+            """
+            return {}
+
 <br>
 
 ## Step 2: Define attributes


### PR DESCRIPTION
The reference "see BundleWrap source code" is intentionally vague. I don't want this to become a dangling pointer because someone restructured `items/__init__.py` and forgot to check the docs.

I expect devs to be able to do a `grep ALLOWED_ITEM_AUTO_ATTRIBUTES -R .` or some equivalent command.

Fixes #904.