### PR TITLE
items/files: fix wrong attribute name

### DIFF
--- a/bundlewrap/items/files.py
+++ b/bundlewrap/items/files.py
@@ -443,7 +443,7 @@ class File(Item):
                 if is_subdirectory(item.name, self.name):
                     deps.add(item.id)
         return {
-            'after': deps,
+            'needs': deps,
         }
 
     def sdict(self):


### PR DESCRIPTION
This was fixed in #900, but accidentially merged wrong in #906