### PR TITLE
items/{directories,files}: zfs dataset mountpoint is optional

### DIFF
--- a/bundlewrap/items/directories.py
+++ b/bundlewrap/items/directories.py
@@ -239,7 +239,7 @@ class Directory(Item):
                 else:
                     deps.add(item.id)
             elif item.ITEM_TYPE_NAME == "zfs_dataset":
-                if item.attributes['mountpoint'] not in (None, "none"):
+                if item.attributes.get('mountpoint') not in (None, "none"):
                     if is_subdirectory(item.attributes['mountpoint'], self.name) or item.attributes['mountpoint'] == self.name:
                         deps.add(item.id)
             elif item.ITEM_TYPE_NAME in ("directory", "symlink"):

--- a/bundlewrap/items/files.py
+++ b/bundlewrap/items/files.py
@@ -441,7 +441,7 @@ class File(Item):
                 else:
                     deps.add(item.id)
             elif item.ITEM_TYPE_NAME == "zfs_dataset":
-                if item.attributes['mountpoint'] not in (None, "none"):
+                if item.attributes.get('mountpoint') not in (None, "none"):
                     if is_subdirectory(item.attributes['mountpoint'], self.name):
                         deps.add(item.id)
             elif item.ITEM_TYPE_NAME in ('directory', 'symlink'):


### PR DESCRIPTION
ZFS dataset supports all attributes, so we have to .get() the attribute