### PR TITLE
doc: items/users: Add brief explanation of bcrypt salt format

### DIFF
--- a/docs/content/items/user.md
+++ b/docs/content/items/user.md
@@ -76,6 +76,8 @@ Hashed password as it would be returned by `crypt()` and written to `/etc/shadow
 
 Recommended for use with the `password` attribute. BundleWrap will use bcrypt with a cost factor of 8 on this salt and the provided password.
 
+bcrypt expects salts to be 16 bytes encoded with the [bcrypt base64 alphabet](https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libc/crypt/bcrypt.c?rev=1.1&content-type=text/x-cvsweb-markup) `./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789` without padding `=` at the end.
+
 <hr>
 
 ## shell


### PR DESCRIPTION
I struggled a while trying to find out why the salt I passed was considered invalid with v5 because I didn't find a description for the format for bcrypt salts and had to look into the source code and google around.

Therefore I suggest adding a little text to the docs explaining the expected format of the salt.

The link to the bcrypt base64 alphabet source code has been taken from the [Wikipedia article of bcrypt](https://en.wikipedia.org/wiki/Bcrypt#Base64_encoding_alphabet), however we could also use the same link as in [crypto.py](https://github.com/bundlewrap/bundlewrap/blob/42d0b6c8376a6d59b89f2c7cda1b6502087ad87c/bundlewrap/utils/crypto.py#L21) to the [rust-base64 implementation](https://github.com/marshallpierce/rust-base64/blob/bc91a05e981345b7da3a5190cd3963eec6e98eb6/src/alphabet.rs#L187).