### PR TITLE
items/svc_systemd: Mask unit only after disabling it

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Simon Brielbeck <simon.brielbeck@seibert.group>
 Peter Körner <git@mazdermind.de>
 Manuel Domke <manuel-domke@gmx.org>
 Sophie Schiller <sophie.schiller@seibert.group>
+Max Jäger <xje4@xje4.eu>

--- a/bundlewrap/items/svc_systemd.py
+++ b/bundlewrap/items/svc_systemd.py
@@ -87,11 +87,8 @@ class SvcSystemd(Item):
         return state
 
     def fix(self, status):
-        if 'masked' in status.keys_to_fix:
-            if self.attributes['masked']:
-                svc_mask(self.node, self.name)
-            else:
-                svc_unmask(self.node, self.name)
+        if 'masked' in status.keys_to_fix and not self.attributes['masked']:
+            svc_unmask(self.node, self.name)
 
         if 'enabled' in status.keys_to_fix:
             if self.attributes['enabled']:
@@ -104,6 +101,9 @@ class SvcSystemd(Item):
                 svc_start(self.node, self.name)
             else:
                 svc_stop(self.node, self.name)
+
+        if 'masked' in status.keys_to_fix and self.attributes['masked']:
+            svc_mask(self.node, self.name)
 
     def get_canned_actions(self):
         return {


### PR DESCRIPTION
When a systemd unit is to be disabled and masked, that needs to happen in this order. If a unit has been masked, systemd refuses to disable it and the symlink in the .wants-directory stays. Same thing applies in the reverse order when unmasking and enabling a unit again. It first has to be unmasked before it can be enabled.

With the current order in which bundlewrap processes a service (first mask/unmask, then enable/disable) this creates a state on the remote system in which the unit is masked but still "enabled". For the unit itself, this has no impact, since a masked unit instantly fails when it's tried to be started (although it's still a bit ugly to have those "orphaned" symlinks in the .wants-directory laying around).
However, there's a bigger impact when the unit has defined `Also` units like NetworkManager. When NetworkManager is disabled regularly, it pulls in `NetworkManager-wait-online` which is then also disabled. When however NetworkManager is masked (and then cannot be disabled anymore), `NetworkManager-wait-online` stays enabled and (since _that_ unit hasn't been masked) is started normally which causes it to wait for NetworkManager which is never gonna be active.

Therefore, fix the order in which systemd-units are masked, unmasked, enabled and disabled so the masking is done at the end while the unmasking stays at the top. This unfortunately requires to do the `if 'masked' in status.keys_to_fix` twice, once for unmasking at the start and again for the masking at the end.