### PR TITLE
PathInfo: 'OpenSSH ECDSA public key' is text as well

### DIFF
--- a/bundlewrap/utils/remote.py
+++ b/bundlewrap/utils/remote.py
@@ -82,6 +82,7 @@ class PathInfo:
             self.desc in (
                 "empty",
                 "JSON data",
+                "OpenSSH ECDSA public key",
                 "OpenSSH ED25519 public key",
                 "OpenSSH RSA public key",
                 "OpenSSH DSA public key",


### PR DESCRIPTION
```
# file /home/upload/.ssh/authorized_keys
/home/upload/.ssh/authorized_keys: OpenSSH ECDSA public key

# head -n1 /home/upload/.ssh/authorized_keys
ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDQdGzwYiallvWXIHgSAf2GOwMJKA8bxPmwyuO+vsd1HwB65hMRPCpKS+FNLIpkrADNnuhGS3xGCGSSuQ+zAu/g=
```

Seems `file` takes the first line to determine the key format.