### PR TITLE
add toml output to bw metadata

### DIFF
--- a/bundlewrap/cmdline/metadata.py
+++ b/bundlewrap/cmdline/metadata.py
@@ -180,7 +180,8 @@ def bw_metadata(repo, args):
             metadata_sorted = _sort_dict_colorblind(metadata)
             if args["toml"]:
                 page_lines(
-                    metadata_to_toml(
+                    force_text(line).replace("\\u001b", "\033")
+                    for line in metadata_to_toml(
                         metadata_sorted,
                         resolve_faults=args['resolve_faults'],
                         sort_keys=False,

--- a/bundlewrap/cmdline/metadata.py
+++ b/bundlewrap/cmdline/metadata.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from sys import exit
 
 from ..exceptions import MetadataUnavailable
-from ..metadata import metadata_to_json
+from ..metadata import metadata_to_json, metadata_to_toml
 from ..utils import Fault, list_starts_with
 from ..utils.cmdline import exit_on_keyboardinterrupt, get_target_nodes
 from ..utils.dicts import (
@@ -176,14 +176,23 @@ def bw_metadata(repo, args):
 
             # now we need to recreate the dict, sorting the keys as if
             # they were not colored (otherwise we'd end up sorted by
-            # color)
+            # co863lor)
             metadata_sorted = _sort_dict_colorblind(metadata)
-
-            page_lines([
-                force_text(line).replace("\\u001b", "\033")
-                for line in metadata_to_json(
-                    metadata_sorted,
-                    resolve_faults=args['resolve_faults'],
-                    sort_keys=False,
-                ).splitlines()
-            ])
+            if args["toml"]:
+                page_lines(
+                    force_text(line).replace("\\u001b", "\033")
+                    for line in metadata_to_toml(
+                        metadata_sorted,
+                        resolve_faults=args['resolve_faults'],
+                        sort_keys=False,
+                    ).splitlines()
+                )
+            else:
+                page_lines([
+                    force_text(line).replace("\\u001b", "\033")
+                    for line in metadata_to_json(
+                        metadata_sorted,
+                        resolve_faults=args['resolve_faults'],
+                        sort_keys=False,
+                    ).splitlines()
+                ])

--- a/bundlewrap/cmdline/metadata.py
+++ b/bundlewrap/cmdline/metadata.py
@@ -180,8 +180,7 @@ def bw_metadata(repo, args):
             metadata_sorted = _sort_dict_colorblind(metadata)
             if args["toml"]:
                 page_lines(
-                    force_text(line).replace("\\u001b", "\033")
-                    for line in metadata_to_toml(
+                    metadata_to_toml(
                         metadata_sorted,
                         resolve_faults=args['resolve_faults'],
                         sort_keys=False,

--- a/bundlewrap/cmdline/metadata.py
+++ b/bundlewrap/cmdline/metadata.py
@@ -176,7 +176,7 @@ def bw_metadata(repo, args):
 
             # now we need to recreate the dict, sorting the keys as if
             # they were not colored (otherwise we'd end up sorted by
-            # co863lor)
+            # color)
             metadata_sorted = _sort_dict_colorblind(metadata)
             if args["toml"]:
                 page_lines(

--- a/bundlewrap/cmdline/metadata.py
+++ b/bundlewrap/cmdline/metadata.py
@@ -182,7 +182,7 @@ def bw_metadata(repo, args):
                 page_lines(
                     force_text(line).replace("\\u001b", "\033")
                     for line in metadata_to_toml(
-                        metadata_sorted,
+                        {"metadata": metadata_sorted},
                         resolve_faults=args['resolve_faults'],
                         sort_keys=False,
                     ).splitlines()

--- a/bundlewrap/cmdline/metadata.py
+++ b/bundlewrap/cmdline/metadata.py
@@ -180,7 +180,7 @@ def bw_metadata(repo, args):
             metadata_sorted = _sort_dict_colorblind(metadata)
             if args["toml"]:
                 page_lines(
-                    force_text(line).replace("\\u001b", "\033")
+                    force_text(line).replace("\\e", "\033")
                     for line in metadata_to_toml(
                         {"metadata": metadata_sorted},
                         resolve_faults=args['resolve_faults'],

--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -736,6 +736,12 @@ will exit with code 47 if any matching items are locked
         dest='resolve_faults',
         help=_("resolve Faults; careful, might contain sensitive data"),
     )
+    parser_metadata.add_argument(
+        "-t", "--toml",
+        action='store_true',
+        dest='toml',
+        help=_("output metadata as toml instead of json"),
+    )
 
     # bw nodes
     help_nodes = _("List nodes in this repository")

--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -1,12 +1,16 @@
 from copy import copy
 from hashlib import sha256
-from json import dumps, JSONEncoder
+from json import JSONEncoder, dumps
+from types import NoneType
+
+from tomlkit import document as toml_document
+from tomlkit import dumps as tomlkit_dumps
 
 from .exceptions import RepositoryError
 from .utils import Fault
 from .utils.dicts import ATOMIC_TYPES, map_dict_keys, merge_dict, value_at_key_path
-from .utils.text import force_text, mark_for_translation as _, yellow
-
+from .utils.text import force_text, yellow
+from .utils.text import mark_for_translation as _
 
 METADATA_TYPES = (  # only meant for natively atomic types
     bool,
@@ -336,6 +340,28 @@ def metadata_to_json(metadata, resolve_faults=True, sort_keys=True):
         sort_keys=sort_keys,
     )
 
+def metadata_dict_to_toml(dict_obj, resolve_faults=False):
+    toml_doc = toml_document()
+    for key, value in dict_obj.items():
+        if isinstance(value, tuple):
+            toml_doc[key] = list(value)
+        elif isinstance(value, set):
+            toml_doc[key] = sorted(value)
+        elif isinstance(value, dict):
+            toml_doc[key] = metadata_dict_to_toml(value, resolve_faults)
+        elif isinstance(value, Fault) and resolve_faults:
+            toml_doc[key] = value.value
+        elif isinstance(value, Fault) and not resolve_faults:
+            toml_doc[key] = yellow(value._repr_first())
+        elif isinstance(value, NoneType):
+            toml_doc[key] = "!none:"
+        else:
+            toml_doc[key] = value
+    return toml_doc
+
+def metadata_to_toml(metadata, resolve_faults=True, sort_keys=True):
+    toml_doc = metadata_dict_to_toml({"metadata": metadata}, resolve_faults=resolve_faults)
+    return tomlkit_dumps(toml_doc)
 
 def hash_metadata(actual_state):
     """

--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -1,7 +1,6 @@
 from copy import copy
 from hashlib import sha256
 from json import JSONEncoder, dumps
-from types import NoneType
 
 from tomlkit import document as toml_document
 from tomlkit import dumps as tomlkit_dumps
@@ -353,7 +352,7 @@ def metadata_dict_to_toml(dict_obj, resolve_faults=False):
             toml_doc[key] = value.value
         elif isinstance(value, Fault) and not resolve_faults:
             toml_doc[key] = yellow(value._repr_first())
-        elif isinstance(value, NoneType):
+        elif value == None:
             toml_doc[key] = "!none:"
         else:
             toml_doc[key] = value

--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -363,7 +363,7 @@ def metadata_dict_to_toml(dict_obj, resolve_faults=False):
 
 
 def metadata_to_toml(metadata, resolve_faults=True, sort_keys=True):
-    toml_doc = metadata_dict_to_toml({"metadata": metadata}, resolve_faults=resolve_faults)
+    toml_doc = metadata_dict_to_toml(metadata, resolve_faults=resolve_faults)
     return tomlkit_dumps(toml_doc)
 
 def hash_metadata(actual_state):

--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -1,8 +1,8 @@
 from copy import copy
 from hashlib import sha256
 from json import JSONEncoder, dumps
-import re
 
+from tomlkit import comment
 from tomlkit import document as toml_document
 from tomlkit import dumps as tomlkit_dumps
 
@@ -344,20 +344,21 @@ def metadata_dict_to_toml(dict_obj, resolve_faults=False):
     toml_doc = toml_document()
     for key, value in dict_obj.items():
         if isinstance(value, tuple):
-            toml_doc[key] = list(value)
+            toml_doc.add(key, list(value))
         elif isinstance(value, set):
-            toml_doc[key] = sorted(value)
+            toml_doc.add(key, sorted(value))
         elif isinstance(value, dict):
-            toml_doc[key] = metadata_dict_to_toml(value, resolve_faults)
+            toml_doc.add(key, metadata_dict_to_toml(value, resolve_faults))
         elif isinstance(value, Fault):
             if resolve_faults:
-                toml_doc[key] = value.value
+                toml_doc.add(key, value.value)
             else:
-                toml_doc[key] = yellow(value._repr_first())
+                toml_doc.add(key, yellow(value._repr_first()))
         elif value is None:
-            toml_doc[key] = "!none:"
+            toml_doc.add(key, "None")
+            toml_doc[key].comment("# was None, but toml can't natively handle NoneType objects")
         else:
-            toml_doc[key] = value
+            toml_doc.add(key, value)
     return toml_doc
 
 

--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -361,19 +361,9 @@ def metadata_dict_to_toml(dict_obj, resolve_faults=False):
     return toml_doc
 
 
-def dumps_ansi(data):
-    toml_str = tomlkit_dumps(data)
-    pattern = r'"([^"\n]*\\u001b[^"\n]*)"'
-    def unquote_match(match):
-        inner = match.group(1)
-        return inner.encode('utf-8').decode('unicode_escape')
-
-    return re.sub(pattern, unquote_match, toml_str)
-
-
 def metadata_to_toml(metadata, resolve_faults=True, sort_keys=True):
     toml_doc = metadata_dict_to_toml({"metadata": metadata}, resolve_faults=resolve_faults)
-    return dumps_ansi(toml_doc)
+    return tomlkit_dumps(toml_doc)
 
 def hash_metadata(actual_state):
     """

--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -349,11 +349,12 @@ def metadata_dict_to_toml(dict_obj, resolve_faults=False):
             toml_doc[key] = sorted(value)
         elif isinstance(value, dict):
             toml_doc[key] = metadata_dict_to_toml(value, resolve_faults)
-        elif isinstance(value, Fault) and resolve_faults:
-            toml_doc[key] = value.value
-        elif isinstance(value, Fault) and not resolve_faults:
-            toml_doc[key] = yellow(value._repr_first())
-        elif value == None:
+        elif isinstance(value, Fault):
+            if resolve_faults:
+                toml_doc[key] = value.value
+            else:
+                toml_doc[key] = yellow(value._repr_first())
+        elif value is None:
             toml_doc[key] = "!none:"
         else:
             toml_doc[key] = value

--- a/bundlewrap/metadata.py
+++ b/bundlewrap/metadata.py
@@ -1,6 +1,7 @@
 from copy import copy
 from hashlib import sha256
 from json import JSONEncoder, dumps
+import re
 
 from tomlkit import document as toml_document
 from tomlkit import dumps as tomlkit_dumps
@@ -358,9 +359,20 @@ def metadata_dict_to_toml(dict_obj, resolve_faults=False):
             toml_doc[key] = value
     return toml_doc
 
+
+def dumps_ansi(data):
+    toml_str = tomlkit_dumps(data)
+    pattern = r'"([^"\n]*\\u001b[^"\n]*)"'
+    def unquote_match(match):
+        inner = match.group(1)
+        return inner.encode('utf-8').decode('unicode_escape')
+
+    return re.sub(pattern, unquote_match, toml_str)
+
+
 def metadata_to_toml(metadata, resolve_faults=True, sort_keys=True):
     toml_doc = metadata_dict_to_toml({"metadata": metadata}, resolve_faults=resolve_faults)
-    return tomlkit_dumps(toml_doc)
+    return dumps_ansi(toml_doc)
 
 def hash_metadata(actual_state):
     """


### PR DESCRIPTION
This is @sschiller-seibert’s PR https://github.com/bundlewrap/bundlewrap/pull/915 with two extra commits (I can’t push on her branch).

First, `metadata_to_toml()` now works like `metadata_to_json()`: No extra `metadata` gets added. This addresses the second half of @fkusei’s comment here https://github.com/bundlewrap/bundlewrap/pull/915#issuecomment-4485839606.

Then, colors have been fixed. Apparently, tomlkit returns the literal string `\e` for escape bytes?

<img width="276" height="109" alt="image" src="https://github.com/user-attachments/assets/46c6f4d9-e55e-4b9a-b915-996b14703e68" />

Works for me now:

<img width="354" height="268" alt="image" src="https://github.com/user-attachments/assets/ec62ea61-283b-4eba-8661-2b35c2f07a74" />

But please run additional tests on your end. Do colors really work for you now? If they don’t, we should drop the color feature from TOML output for now (as @fkusei suggested), so we can get this merged soon.