### PR TITLE
fix: Add empty string as default for routeros `actual_state`

### DIFF
--- a/bundlewrap/items/routeros.py
+++ b/bundlewrap/items/routeros.py
@@ -97,6 +97,12 @@ class RouterOS(Item):
         if state:
             # API doesn't return comment at all if emtpy
             state.setdefault('comment', '')
+
+            # Set all expected keys to default to empty string
+            for key in self.expected_state:
+                if key not in state:
+                    state.setdefault(key, '')
+
             # undo automatic type conversion in librouteros
             for key, value in tuple(state.items()):
                 if value is True:


### PR DESCRIPTION
The RouterOS API does not return attributes that are not set sometimes. By defaulting all expected keys to empty-string, we can mitigate this problem.

The problem actually appears when applying, as some code expects all keys from `expected_state` to also exist in `actual_state`, which was not given before.