### PR TITLE
`bw lock add`: Allow users to set a default for `--skip-item-verification`

### DIFF
--- a/bundlewrap/cmdline/parser.py
+++ b/bundlewrap/cmdline/parser.py
@@ -1,4 +1,5 @@
-from argparse import ArgumentParser, RawTextHelpFormatter, SUPPRESS
+from argparse import (ArgumentParser, BooleanOptionalAction,
+                      RawTextHelpFormatter, SUPPRESS)
 from os import environ, getcwd
 from os.path import join
 
@@ -581,7 +582,8 @@ bundle:my_bundle  # items in this bundle
     )
     parser_lock_add.add_argument(
         "--skip-item-verification",
-        action='store_true',
+        action=BooleanOptionalAction,
+        default=bool(int(environ.get('BW_LOCK_ADD_SKIP_ITEM_VERIFICATION', 0))),
         dest='skip_item_verification',
         help=_("disable verification of item selector (-i)"),
     )


### PR DESCRIPTION
This feature got introduced in bw 5.0.0. Problem is, it can be very costly because it requires bw to generate all items for a node. Nobody cares on small nodes, but on large nodes with lots of metadata reactors, this can take several *minutes*.

So, allow users to customize this by setting `$BW_LOCK_ADD_SKIP_ITEM_VERIFICATION`.

Here's a demo (with a little patch that only prints the value of `args['skip_item_verification']` without actually locking anything):

    $ bw lock add bignode -e 1m
    False
    $ bw lock add bignode -e 1m --skip-item-verification
    True
    $ bw lock add bignode -e 1m --no-skip-item-verification
    False

    $ BW_LOCK_ADD_SKIP_ITEM_VERIFICATION=0 bw lock add bignode -e 1m
    False
    $ BW_LOCK_ADD_SKIP_ITEM_VERIFICATION=0 bw lock add bignode -e 1m --skip-item-verification
    True
    $ BW_LOCK_ADD_SKIP_ITEM_VERIFICATION=0 bw lock add bignode -e 1m --no-skip-item-verification
    False

    $ BW_LOCK_ADD_SKIP_ITEM_VERIFICATION=1 bw lock add bignode -e 1m
    True
    $ BW_LOCK_ADD_SKIP_ITEM_VERIFICATION=1 bw lock add bignode -e 1m --skip-item-verification
    True
    $ BW_LOCK_ADD_SKIP_ITEM_VERIFICATION=1 bw lock add bignode -e 1m --no-skip-item-verification
    False

Requires Python 3.9+ because of `BooleanOptionalAction`.