### PR TITLE
 Introduce new 'ok_when' attribute to let actions be OK instead of SKIPPED

### DIFF
--- a/bundlewrap/items/__init__.py
+++ b/bundlewrap/items/__init__.py
@@ -34,6 +34,7 @@ BUILTIN_ITEM_ATTRIBUTES = {
     'comment': None,
     'needed_by': set(),
     'needs': set(),
+    'ok_when': "",
     'preceded_by': set(),
     'precedes': set(),
     'error_on_missing_fault': False,
@@ -337,16 +338,32 @@ class Item:
         else:
             return False
 
+    @cached_property
+    def cached_ok_when_result(self):
+        """
+        Returns True if 'ok_when' wants to skip this item.
+        """
+        if self.ok_when and (self.ITEM_TYPE_NAME == 'action' or not self.cached_status.correct):
+            with io.job(_("{node}  {bundle}  {item}  running 'ok_when' ...").format(
+                bundle=bold(self.bundle.name),
+                item=self.id,
+                node=bold(self.node.name),
+            )):
+                ok_when_result = self.node.run(self.ok_when, may_fail=True)
+                return ok_when_result.return_code == 0
+        else:
+            return False
+
     def _triggers_preceding_items(self, interactive=False):
         """
         Preceding items will execute this to figure out if they're
         triggered.
         """
-        if self.cached_unless_result:
-            # 'unless' says we don't need to run
+        if self.cached_unless_result or self.cached_ok_when_result:
+            # 'unless' or 'ok_when' says we don't need to run
             return False
         if self.ITEM_TYPE_NAME == 'action':
-            # so we have an action where 'unless' says it must be run
+            # so we have an action where 'unless' and 'ok_when' says it must be run
             # but the 'interactive' attribute might still override that
             if self.attributes['interactive'] and not interactive:
                 return False
@@ -578,6 +595,11 @@ class Item:
                     ).format(item=self.id, node=self.node.name))
                     status_code = self.STATUS_SKIPPED
                     details = self.SKIP_REASON_UNLESS
+                elif self.cached_ok_when_result:
+                    io.debug(_(
+                        "'ok_when' for {item} on {node} succeeded, not fixing"
+                    ).format(item=self.id, node=self.node.name))
+                    status_code = self.STATUS_OK
                 elif status_before.correct:
                     status_code = self.STATUS_OK
                 elif show_diff or interactive:
@@ -825,7 +847,7 @@ class Item:
                 copy(self.cached_status.actual_state),
                 copy(self.cached_status.keys_to_fix),
             )
-        return self.cached_unless_result, self.cached_status, display
+        return self.cached_unless_result, self.cached_ok_when_result, self.cached_status, display
 
     def display_on_create(self, expected_state):
         """

--- a/bundlewrap/items/actions.py
+++ b/bundlewrap/items/actions.py
@@ -114,6 +114,24 @@ class Action(Item):
                 ))
                 return (self.STATUS_SKIPPED, self.SKIP_REASON_UNLESS, None, None)
 
+        if self.ok_when:
+            with io.job(_("{node}  {bundle}  {item}  checking 'ok_when' condition").format(
+                bundle=bold(self.bundle.name),
+                item=self.id,
+                node=bold(self.node.name),
+            )):
+                ok_when_result = self.bundle.node.run(
+                    self.ok_when,
+                    may_fail=True,
+                )
+            if ok_when_result.return_code == 0:
+                io.debug(_("{node}:{bundle}:action:{name}: succeeded 'ok_when', not running").format(
+                    bundle=self.bundle.name,
+                    name=self.name,
+                    node=self.bundle.node.name,
+                ))
+                return (self.STATUS_OK, None, None, None)
+
         question_body = ""
         if self.attributes['data_stdin'] is not None:
             question_body += "<" + _("data") + "> | "
@@ -250,7 +268,7 @@ class Action(Item):
             ).format(item=self.id, node=self.node.name))
             raise ItemSkipped
 
-        if self.unless and self.cached_unless_result:
-            return self.cached_unless_result, None, None
+        if (self.unless and self.cached_unless_result) or (self.ok_when and self.cached_ok_when_result):
+            return self.cached_unless_result, self.cached_ok_when_result, None, None
         else:
             raise NotImplementedError

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -1201,9 +1201,9 @@ def verify_items(
 
     def handle_result(task_id, return_value, duration):
         io.progress_advance()
-        unless_result, item_status, display = return_value
+        unless_result, ok_when_result, item_status, display = return_value
         node_name, bundle_name, item_id = task_id.split(":", 2)
-        if not unless_result and not item_status.correct:
+        if not unless_result and not ok_when_result and not item_status.correct:
             if item_status.must_be_created:
                 details_text = red(_("missing"))
             elif item_status.must_be_deleted:

--- a/tests/integration/bw_apply_actions.py
+++ b/tests/integration/bw_apply_actions.py
@@ -1,4 +1,5 @@
 from bundlewrap.utils.testing import host_os, make_repo, run
+from os.path import join
 
 
 def test_action_success(tmpdir):
@@ -141,3 +142,78 @@ def test_action_return_codes(tmpdir):
     )
     stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
     assert rcode == 0
+
+
+def test_action_ok_when(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'items': {
+                    'actions': {
+                        "action1": {
+                            'command': "echo 1 >> {}".format(join(str(tmpdir), "file")),
+                            'ok_when': 'true',
+                        },
+                        "action2": {
+                            'command': "echo 2 >> {}".format(join(str(tmpdir), "file")),
+							'ok_when': 'false',
+                            'needs': ["action:action1"],
+                        },
+                    },
+                },
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
+    with open(join(str(tmpdir), "file")) as f:
+        content = f.read()
+    assert content == "2\n"
+
+
+def test_action_ok_when2(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'items': {
+                    'actions': {
+                        "action1": {
+                            'command': "false",
+							'ok_when': 'false',
+                        },
+                        "action2": {
+                            'command': "echo 2 >> {}".format(join(str(tmpdir), "file")),
+                            'needs': ["action:action1"],
+                        },
+						"action3": {
+                            'command': "echo 3 >> {}".format(join(str(tmpdir), "file")),
+                            'after': ["action:action2"],
+                        },
+                    },
+                },
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 1
+
+    with open(join(str(tmpdir), "file")) as f:
+        content = f.read()
+    assert content == "3\n"

--- a/tests/integration/bw_apply_precedes.py
+++ b/tests/integration/bw_apply_precedes.py
@@ -217,6 +217,135 @@ def test_precedes_unless4(tmpdir):
     assert content == "1\n"
 
 
+def test_precedes_ok_when(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'items': {
+                    'files': {
+                        join(str(tmpdir), "file"): {
+                            'content': "1\n",
+                            'triggered': True,
+                            'precedes': ["tag:tag1"],
+                        },
+                    },
+                    'actions': {
+                        "action2": {
+                            'command': "echo 2 >> {}".format(join(str(tmpdir), "file")),
+                            'tags': ["tag1"],
+                            'ok_when': 'true',
+                        },
+                        "action3": {
+                            'command': "echo 3 >> {}".format(join(str(tmpdir), "file")),
+                            'tags': ["tag1"],
+                            'needs': ["action:action2"],
+                        },
+                    },
+                },
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
+    with open(join(str(tmpdir), "file")) as f:
+        content = f.read()
+    assert content == "1\n3\n"
+
+
+def test_precedes_ok_whens2(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'items': {
+                    'files': {
+                        join(str(tmpdir), "file"): {
+                            'content': "1\n",
+                            'triggered': True,
+                            'precedes': ["tag:tag1"],
+                        },
+                    },
+                    'actions': {
+                        "action2": {
+                            'command': "echo 2 >> {}".format(join(str(tmpdir), "file")),
+                            'tags': ["tag1"],
+                            'ok_when': 'true',
+                        },
+                        "action3": {
+                            'command': "echo 3 >> {}".format(join(str(tmpdir), "file")),
+                            'tags': ["tag1"],
+                            'needs': ["action:action2"],
+                            'ok_when': 'true',
+                        },
+                    },
+                },
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+    assert not exists(join(str(tmpdir), "file"))
+
+
+def test_precedes_ok_when3(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'items': {
+                    'files': {
+                        join(str(tmpdir), "file"): {
+                            'content': "1\n",
+                            'triggered': True,
+                            'precedes': ["tag:tag1"],
+                            'ok_when': 'true',
+                        },
+                    },
+                    'actions': {
+                        "action2": {
+                            'command': "echo 2 >> {}".format(join(str(tmpdir), "file")),
+                            'tags': ["tag1"],
+                        },
+                        "action3": {
+                            'command': "echo 3 >> {}".format(join(str(tmpdir), "file")),
+                            'tags': ["tag1"],
+                            'needs': ["action:action2"],
+                        },
+                    },
+                },
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+
+    stdout, stderr, rcode = run("bw apply localhost", path=str(tmpdir))
+    assert rcode == 0
+
+    with open(join(str(tmpdir), "file")) as f:
+        content = f.read()
+    assert content == "2\n3\n"
+
+
 def test_precedes_action(tmpdir):
     make_repo(
         tmpdir,

--- a/tests/integration/bw_items.py
+++ b/tests/integration/bw_items.py
@@ -409,6 +409,7 @@ comment\tNone
 error_on_missing_fault\tFalse
 needed_by\t[]
 needs\taction:
+ok_when\t
 preceded_by\t[]
 precedes\t[]
 skip\tFalse
@@ -435,6 +436,7 @@ def test_bw_items_invocation_single_item_attrs_as_json(tmpdir):
     "needs": [
         "action:"
     ],
+    "ok_when": "",
     "preceded_by": [],
     "precedes": [],
     "skip": false,


### PR DESCRIPTION
As described in #987 I see the need for a way to let actions gain STATUS_OK to be able to distinguish between a executed-but-failed and a not-executed-because-nothing-to-do action (or any item in general).

Currently, actions may only ever gain STATUS_FIXED, STATUS_SKIPPED or STATUS_FAILED.
This becomes an issue when there's a heavy action which shall only be executed when necessary and other items depending on that action.

When the action succeeds, everything is fine.
Then the second time, the action is skipped because of an `unless`. And to not skip all dependent items, `cascade_skip: False` is implied to the action because of the `unless` attribute.
However, when the action fails, this is treated the same as an `unless`-skip and since `cascade_skip` is still false, all dependent items don't care and are executed nonetheless, despite on of their dependencies not being ready.

To solve this, a new `ok_when` attribute (the name is kinda lame and inspired by Ansible's naming. Open to better naming proposals) is introduced which works kinda like `unless`, however instead of implying `cascade_skip` and letting the item be skipped when nothing is to be done, the item just gains STATUS_OK if the condition/test succeeds.

This is basically the action-version of an item whose task is already completed like a `file` which contains already the expected content or a `svc_systemd` which is already running and enabled.
Same now goes for an `action` which just doesn't need to be run because its task has already been fulfilled in the past, there is nothing to fix or do and so the item can just report STATUS_OK.

---

I've not _yet_ included documentation in this PR as I wanted to know your stance about this change beforehand.
My take for the documentation would be to recommend this attribute over `unless` because to me it feels much more intuitive that subsequent/dependent items are skipped when an action fails and I've been biten a couple of times with the current behaviour of `unless`.
