### PR TITLE
bw verify: skip items with unavailable Faults instead of tracebacks

### DIFF
--- a/bundlewrap/cmdline/diff.py
+++ b/bundlewrap/cmdline/diff.py
@@ -2,11 +2,11 @@ from copy import copy
 from difflib import unified_diff
 from sys import exit
 
-from ..exceptions import NoSuchItem
+from ..exceptions import FaultUnavailable, NoSuchItem
 from ..metadata import metadata_to_json
 from ..repo import Repository
 from ..utils.cmdline import get_target_nodes
-from ..utils.dicts import diff_dict, dict_to_text
+from ..utils.dicts import diff_dict, dict_to_text, hash_state_dict
 from ..utils.scm import get_git_branch, get_git_rev, set_git_rev
 from ..utils.text import (
     bold,
@@ -23,9 +23,86 @@ from ..utils.ui import io, QUIT_EVENT
 from subprocess import check_call
 
 
+def _report_fault_unavailable(item):
+    io.stderr(_("{x} {node}  {bundle}  {item}  ({msg})").format(
+        bundle=bold(item.bundle.name),
+        item=item.id,
+        msg=yellow(_("Fault unavailable")),
+        node=bold(item.node.name),
+        x=yellow("»"),
+    ))
+
+
+def _metadata_lines_pair(node_a, node_b):
+    """
+    Returns the metadata of both nodes as JSON lines. If a Fault cannot
+    be resolved on either side, *both* sides are rendered with
+    unresolved Faults so the diff doesn't show spurious differences.
+    """
+    try:
+        return (
+            metadata_to_json(node_a.metadata).splitlines(),
+            metadata_to_json(node_b.metadata).splitlines(),
+        )
+    except FaultUnavailable:
+        io.stderr(_("{x} Fault unavailable, showing unresolved Faults").format(
+            x=yellow("»"),
+        ))
+        return (
+            metadata_to_json(node_a.metadata, resolve_faults=False).splitlines(),
+            metadata_to_json(node_b.metadata, resolve_faults=False).splitlines(),
+        )
+
+
+def _metadata_hashes(node):
+    """
+    Returns (hash_resolved, hash_unresolved) for the node's metadata.
+    hash_resolved is None if a Fault is unavailable.
+    """
+    hash_unresolved = hash_state_dict(metadata_to_json(node.metadata, resolve_faults=False))
+    try:
+        return (node.metadata_hash(), hash_unresolved)
+    except FaultUnavailable:
+        io.stderr(_("{x} {node}  Fault unavailable, hashing unresolved Faults").format(
+            node=bold(node.name),
+            x=yellow("»"),
+        ))
+        return (None, hash_unresolved)
+
+
+def _pick_comparable_hashes(before, after):
+    """
+    Given two dicts of {node_name: (hash_resolved, hash_unresolved)},
+    return two dicts of {node_name: hash} using the resolved hash only
+    where it is available on both sides.
+    """
+    picked_before = {}
+    picked_after = {}
+    for node_name in before:
+        resolved_before, unresolved_before = before[node_name]
+        resolved_after, unresolved_after = after[node_name]
+        if resolved_before is None or resolved_after is None:
+            picked_before[node_name] = unresolved_before
+            picked_after[node_name] = unresolved_after
+        else:
+            picked_before[node_name] = resolved_before
+            picked_after[node_name] = resolved_after
+    return picked_before, picked_after
+
+
+def _item_display_dict(item):
+    """
+    Returns the expected_state of an item prepared for display, or None
+    for items that are to be deleted. Raises FaultUnavailable.
+    """
+    expected_state = item.cached_expected_state
+    if expected_state is None:
+        return None
+    return item.display_on_create(copy(expected_state))
+
+
 def diff_metadata(node_a, node_b):
-    node_a_metadata = metadata_to_json(node_a.metadata).splitlines()
-    node_b_metadata = metadata_to_json(node_b.metadata).splitlines()
+    node_a_metadata, node_b_metadata = _metadata_lines_pair(node_a, node_b)
     io.stdout("\n".join(unified_diff(
         node_a_metadata,
         node_b_metadata,
@@ -36,11 +113,15 @@ def diff_metadata(node_a, node_b):
 
 
 def diff_item(node_a, node_b, item):
-    item_a = node_a.get_item(item)
-    item_a_dict = item_a.display_on_create(item_a.expected_state.copy())
-    item_b = node_b.get_item(item)
-    item_b_dict = item_b.display_on_create(item_b.expected_state.copy())
-    io.stdout(diff_dict(item_a_dict, item_b_dict))
+    dicts = []
+    for node in (node_a, node_b):
+        node_item = node.get_item(item)
+        try:
+            dicts.append(_item_display_dict(node_item) or {})
+        except FaultUnavailable:
+            _report_fault_unavailable(node_item)
+            exit(1)
+    io.stdout(diff_dict(*dicts))
 
 
 def diff_node(node_a, node_b):
@@ -93,14 +174,19 @@ def git_checkout_closure(rev, detach=False):
 
 
 def hooked_diff_metadata_single_node(repo, node, intermissions, epilogues):
-    node_before_metadata = metadata_to_json(node.metadata).splitlines()
+    node.metadata.get(tuple())  # build metadata before the repo changes
 
-    for intermission in intermissions:
-        intermission()
+    try:
+        for intermission in intermissions:
+            intermission()
 
-    after_repo = Repository(repo.path)
-    node_after = after_repo.get_node(node.name)
-    node_after_metadata = metadata_to_json(node_after.metadata).splitlines()
+        after_repo = Repository(repo.path)
+        node_after = after_repo.get_node(node.name)
+        node_before_metadata, node_after_metadata = _metadata_lines_pair(node, node_after)
+    finally:
+        for epilogue in epilogues:
+            epilogue()
+
     io.stdout("\n".join(unified_diff(
         node_before_metadata,
         node_after_metadata,
@@ -109,27 +195,33 @@ def hooked_diff_metadata_single_node(repo, node, intermissions, epilogues):
         lineterm='',
     )))
 
-    for epilogue in epilogues:
-        epilogue()
-
 
 def hooked_diff_metadata_multiple_nodes(repo, nodes, intermissions, epilogues):
     nodes_metadata_before = {}
     for node in nodes:
         if QUIT_EVENT.is_set():
             exit(1)
-        nodes_metadata_before[node.name] = node.metadata_hash()
+        nodes_metadata_before[node.name] = _metadata_hashes(node)
 
-    for intermission in intermissions:
-        intermission()
+    try:
+        for intermission in intermissions:
+            intermission()
 
-    after_repo = Repository(repo.path)
-    nodes_metadata_after = {}
-    for node_name in nodes_metadata_before:
-        if QUIT_EVENT.is_set():
-            exit(1)
-        nodes_metadata_after[node_name] = \
-            after_repo.get_node(node_name).metadata_hash()
+        after_repo = Repository(repo.path)
+        nodes_metadata_after = {}
+        for node_name in nodes_metadata_before:
+            if QUIT_EVENT.is_set():
+                exit(1)
+            nodes_metadata_after[node_name] = \
+                _metadata_hashes(after_repo.get_node(node_name))
+    finally:
+        for epilogue in epilogues:
+            epilogue()
+
+    nodes_metadata_before, nodes_metadata_after = _pick_comparable_hashes(
+        nodes_metadata_before,
+        nodes_metadata_after,
+    )
 
     node_hashes_before = sorted(
         ["{}\t{}".format(i, h) for i, h in nodes_metadata_before.items()]
@@ -151,38 +243,47 @@ def hooked_diff_metadata_multiple_nodes(repo, nodes, intermissions, epilogues):
         ),
     ))
 
-    for epilogue in epilogues:
-        epilogue()
-
 
 def hooked_diff_single_item(repo, node, item, intermissions, epilogues):
+    fault_unavailable = False
     try:
         item_before = node.get_item(item)
     except NoSuchItem:
         item_before = None
         item_before_dict = None
     else:
-        item_before_dict = item_before.expected_state
-        if item_before_dict:
-            item_before_dict = item_before.display_on_create(copy(item_before_dict))
+        try:
+            item_before_dict = _item_display_dict(item_before)
+        except FaultUnavailable:
+            _report_fault_unavailable(item_before)
+            fault_unavailable = True
+            item_before_dict = None
 
-    for intermission in intermissions:
-        intermission()
-
-    repo_after = Repository(repo.path)
-    node_after = repo_after.get_node(node.name)
     try:
-        item_after = node_after.get_item(item)
-    except NoSuchItem:
-        item_after = None
-        item_after_dict = None
-    else:
-        item_after_dict = item_after.expected_state
-        if item_after_dict:
-            item_after_dict = item_after.display_on_create(copy(item_after_dict))
+        for intermission in intermissions:
+            intermission()
 
-    for epilogue in epilogues:
-        epilogue()
+        repo_after = Repository(repo.path)
+        node_after = repo_after.get_node(node.name)
+        try:
+            item_after = node_after.get_item(item)
+        except NoSuchItem:
+            item_after = None
+            item_after_dict = None
+        else:
+            try:
+                item_after_dict = _item_display_dict(item_after)
+            except FaultUnavailable:
+                _report_fault_unavailable(item_after)
+                fault_unavailable = True
+                item_after_dict = None
+    finally:
+        for epilogue in epilogues:
+            epilogue()
+
+    if fault_unavailable:
+        # showing only one side would look like the item was added or removed
+        exit(1)
 
     if item_before is None and item_after is None:
         io.stderr(_("{x} {node}  {item}  not found anywhere").format(
@@ -233,24 +334,18 @@ def hooked_diff_single_item(repo, node, item, intermissions, epilogues):
 
 
 def hooked_diff_config_single_node(repo, node, intermissions, epilogues):
-    item_hashes_before = {
-        item.id: item.hash() for item in node.items
-        if item.ITEM_TYPE_NAME != 'action'
-    }
+    item_hashes_before = node.expected_state
 
-    for intermission in intermissions:
-        intermission()
+    try:
+        for intermission in intermissions:
+            intermission()
 
-    after_repo = Repository(repo.path)
-    after_node = after_repo.get_node(node.name)
-
-    item_hashes_after = {
-        item.id: item.hash() for item in after_node.items
-        if item.ITEM_TYPE_NAME != 'action'
-    }
-
-    for epilogue in epilogues:
-        epilogue()
+        after_repo = Repository(repo.path)
+        after_node = after_repo.get_node(node.name)
+        item_hashes_after = after_node.expected_state
+    finally:
+        for epilogue in epilogues:
+            epilogue()
 
     item_hashes_before = sorted(
         ["{}\t{}".format(i, h) for i, h in item_hashes_before.items()]
@@ -278,18 +373,22 @@ def hooked_diff_config_multiple_nodes(repo, nodes, intermissions, epilogues):
     for node in nodes:
         if QUIT_EVENT.is_set():
             exit(1)
-        nodes_config_before[node.name] = node.hash()
+        nodes_config_before[node.name] = hash_state_dict(node.expected_state)
 
-    for intermission in intermissions:
-        intermission()
+    try:
+        for intermission in intermissions:
+            intermission()
 
-    after_repo = Repository(repo.path)
-    nodes_config_after = {}
-    for node_name in nodes_config_before:
-        if QUIT_EVENT.is_set():
-            exit(1)
-        nodes_config_after[node_name] = \
-            after_repo.get_node(node_name).hash()
+        after_repo = Repository(repo.path)
+        nodes_config_after = {}
+        for node_name in nodes_config_before:
+            if QUIT_EVENT.is_set():
+                exit(1)
+            nodes_config_after[node_name] = \
+                hash_state_dict(after_repo.get_node(node_name).expected_state)
+    finally:
+        for epilogue in epilogues:
+            epilogue()
 
     node_hashes_before = sorted(
         ["{}\t{}".format(i, h) for i, h in nodes_config_before.items()]
@@ -310,9 +409,6 @@ def hooked_diff_config_multiple_nodes(repo, nodes, intermissions, epilogues):
             ),
         ),
     ))
-
-    for epilogue in epilogues:
-        epilogue()
 
 
 def bw_diff(repo, args):

--- a/bundlewrap/cmdline/hash.py
+++ b/bundlewrap/cmdline/hash.py
@@ -1,8 +1,8 @@
 from sys import exit
 
-from ..exceptions import NoSuchGroup, NoSuchNode
+from ..exceptions import FaultUnavailable, NoSuchGroup, NoSuchNode
 from ..utils.cmdline import get_item
-from ..utils.text import mark_for_translation as _, red
+from ..utils.text import bold, mark_for_translation as _, red
 from ..utils.ui import io
 
 
@@ -48,6 +48,20 @@ def bw_hash(repo, args):
         io.stdout(_("{x} Cannot select item for group").format(x=red("!!!")))
         exit(1)
 
+    try:
+        _hash_or_dict(target, target_type, args)
+    except FaultUnavailable as exc:
+        io.stderr(_(
+            "{x} cannot hash {target} (Fault unavailable): {exc}"
+        ).format(
+            exc=exc,
+            target=bold(args['item'] or args['node_or_group'] or _("repo")),
+            x=red("!!!"),
+        ))
+        exit(1)
+
+
+def _hash_or_dict(target, target_type, args):
     if args['dict']:
         if args['group_membership']:
             if target_type in ('node', 'repo'):
@@ -60,7 +74,11 @@ def bw_hash(repo, args):
             for node in sorted(target.nodes):
                 io.stdout("{}\t{}".format(node.name, node.metadata_hash()))
         else:
-            expected_state = target.cached_expected_state if args['item'] else target.expected_state
+            if args['item']:
+                expected_state = target.cached_expected_state
+            else:
+                target.hash()  # raises FaultUnavailable for incomplete expected_state
+                expected_state = target.expected_state
             if expected_state is None:
                 io.stdout("REMOVE")
             else:

--- a/bundlewrap/cmdline/items.py
+++ b/bundlewrap/cmdline/items.py
@@ -147,7 +147,13 @@ def show_single_item(node, item, representation, args):
         data = item.actual_state
 
     elif representation == ItemRepresentation.EXPECTED_STATE:
-        data = item.expected_state
+        try:
+            data = item.cached_expected_state
+        except FaultUnavailable:
+            io.stderr(_(
+                "{x} cannot show expected state of {item} on {node} (Fault unavailable)"
+            ).format(x=red("!!!"), item=item.id, node=node.name))
+            exit(1)
 
     elif representation == ItemRepresentation.REPR:
         data = [repr(item)]

--- a/bundlewrap/cmdline/test.py
+++ b/bundlewrap/cmdline/test.py
@@ -130,12 +130,85 @@ def test_empty_groups(repo):
         exit(1)
 
 
-def test_determinism(repo, nodes, iterations_config, iterations_metadata, quiet):
+def _report_missing_fault(node, exc, ignore_missing_faults):
+    if ignore_missing_faults:
+        io.stderr(_("{x} {node}  cannot check determinism ({msg}: {exc})").format(
+            exc=exc,
+            msg=yellow(_("Fault unavailable")),
+            node=bold(node.name),
+            x=yellow("»"),
+        ))
+    else:
+        io.stderr(_("{x} {node}  cannot check determinism, Fault unavailable: {exc}").format(
+            exc=exc,
+            node=bold(node.name),
+            x=red("✘"),
+        ))
+        exit(1)
+
+
+def _report_config_changed(node, first_run_node):
+    io.stderr(_(
+        "{x} Configuration for node {node} changed when generated repeatedly"
+    ).format(node=node.name, x=red("✘")))
+    heisenitems = set(node.items).symmetric_difference(set(first_run_node.items))
+    if heisenitems:
+        io.stderr(_(
+            "{x} These items appeared or disappeared on {node} between runs:\n"
+            "\t{items}"
+        ).format(
+            x=red("✘"),
+            node=node.name,
+            items="\n\t".join(sorted({item.id for item in heisenitems})),
+        ))
+        exit(1)
+    for item in node.items:
+        previous_item = first_run_node.get_item(item.id)
+        if item.ITEM_TYPE_NAME == "action":
+            continue  # actions don't hash :'(
+        if item.hash() != previous_item.hash():
+            current_expected_state = item.display_on_create(item.expected_state.copy())
+            previous_expected_state = previous_item.display_on_create(
+                previous_item.expected_state.copy()
+            )
+            output = _("{x} {node}  {item} changed:\n").format(
+                x=red("✘"),
+                node=bold(node.name),
+                item=item.id,
+            )
+            diff = diff_dict(current_expected_state, previous_expected_state)
+            output += prefix_lines(diff, red("│ "))
+            output += red("╵")
+            io.stderr(output)
+    exit(1)
+
+
+def _report_metadata_changed(node, first_run_node):
+    io.stderr(_(
+        "{x} Metadata for node {node} changed when generated repeatedly"
+    ).format(node=bold(node.name), x=red("✘")))
+    previous_json = metadata_to_json(first_run_node.metadata)
+    current_json = metadata_to_json(node.metadata)
+    io.stderr(diff_text(previous_json, current_json))
+    exit(1)
+
+
+def test_determinism(
+    repo,
+    nodes,
+    iterations_config,
+    iterations_metadata,
+    ignore_missing_faults,
+    quiet,
+):
     """
     Generate configuration a couple of times for every node and see if
     anything changes between iterations
     """
     first_run_nodes = {}
+    # nodes reported once for missing Faults are not rendered again
+    config_missing_faults = set()
+    metadata_missing_faults = set()
     io.progress_set_total(len(nodes) * (iterations_config + iterations_metadata))
 
     iter_config_todo = iterations_config
@@ -154,63 +227,42 @@ def test_determinism(repo, nodes, iterations_config, iterations_metadata, quiet)
 
             first_run_nodes.setdefault(node.name, node)
 
-            if iter_config_todo > 0:
-                with io.job(_("{node}  generating configuration ({i}/{n})").format(
-                    i=iterations_config - iter_config_todo,
-                    n=iterations_config,
-                    node=bold(node.name),
-                )):
-                    result = node.hash()
-                if first_run_nodes[node.name].hash() != result:
-                    io.stderr(_(
-                        "{x} Configuration for node {node} changed when generated repeatedly"
-                    ).format(node=node.name, x=red("✘")))
-                    heisenitems = set(node.items).symmetric_difference(
-                        set(first_run_nodes[node.name].items))
-                    if heisenitems:
-                        io.stderr(_(
-                            "{x} These items appeared or disappeared on {node} between runs:\n"
-                            "\t{items}"
-                        ).format(
-                            x=red("✘"),
-                            node=node.name,
-                            items="\n\t".join(sorted({item.id for item in heisenitems})),
-                        ))
-                        exit(1)
-                    for item in node.items:
-                        previous_item = first_run_nodes[node.name].get_item(item.id)
-                        if item.ITEM_TYPE_NAME == "action":
-                            continue  # actions don't hash :'(
-                        if item.hash() != previous_item.hash():
-                            current_expected_state = item.display_on_create(item.expected_state.copy())
-                            previous_expected_state = previous_item.display_on_create(previous_item.expected_state.copy())
-                            output = _("{x} {node}  {item} changed:\n").format(
-                                x=red("✘"),
-                                node=bold(node.name),
-                                item=item.id,
-                            )
-                            diff = diff_dict(current_expected_state, previous_expected_state)
-                            output += prefix_lines(diff, red("│ "))
-                            output += red("╵")
-                            io.stderr(output)
-                    exit(1)
+            if iter_config_todo > 0 and node.name in config_missing_faults:
+                io.progress_advance()
+            elif iter_config_todo > 0:
+                try:
+                    with io.job(_("{node}  generating configuration ({i}/{n})").format(
+                        i=iterations_config - iter_config_todo,
+                        n=iterations_config,
+                        node=bold(node.name),
+                    )):
+                        result = node.hash()
+                    previous_result = first_run_nodes[node.name].hash()
+                except FaultUnavailable as exc:
+                    _report_missing_fault(node, exc, ignore_missing_faults)
+                    config_missing_faults.add(node.name)
+                else:
+                    if previous_result != result:
+                        _report_config_changed(node, first_run_nodes[node.name])
                 io.progress_advance()
 
-            if iter_metadata_todo > 0:
-                with io.job(_("{node}  generating metadata ({i}/{n})").format(
-                    i=iterations_metadata - iter_metadata_todo,
-                    n=iterations_metadata,
-                    node=bold(node.name),
-                )):
-                    result = node.metadata_hash()
-                if first_run_nodes[node.name].metadata_hash() != result:
-                    io.stderr(_(
-                        "{x} Metadata for node {node} changed when generated repeatedly"
-                    ).format(node=bold(node.name), x=red("✘")))
-                    previous_json = metadata_to_json(first_run_nodes[node.name].metadata)
-                    current_json = metadata_to_json(node.metadata)
-                    io.stderr(diff_text(previous_json, current_json))
-                    exit(1)
+            if iter_metadata_todo > 0 and node.name in metadata_missing_faults:
+                io.progress_advance()
+            elif iter_metadata_todo > 0:
+                try:
+                    with io.job(_("{node}  generating metadata ({i}/{n})").format(
+                        i=iterations_metadata - iter_metadata_todo,
+                        n=iterations_metadata,
+                        node=bold(node.name),
+                    )):
+                        result = node.metadata_hash()
+                    previous_result = first_run_nodes[node.name].metadata_hash()
+                except FaultUnavailable as exc:
+                    _report_missing_fault(node, exc, ignore_missing_faults)
+                    metadata_missing_faults.add(node.name)
+                else:
+                    if previous_result != result:
+                        _report_metadata_changed(node, first_run_nodes[node.name])
                 io.progress_advance()
 
         if iter_config_todo > 0:
@@ -310,6 +362,7 @@ def bw_test(repo, args):
             nodes,
             args['determinism_config'],
             args['determinism_metadata'],
+            args['ignore_missing_faults'],
             args['quiet'],
         )
 

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -13,6 +13,7 @@ from .concurrency import WorkerPool
 from .deps import find_item, ItemDependencyLoop
 from .exceptions import (
     BundleError,
+    FaultUnavailable,
     GracefulApplyException,
     ItemSkipped,
     NodeLockedException,
@@ -605,7 +606,16 @@ class Node:
         node_dict = {}
         for item in self.items:
             if item.ITEM_TYPE_NAME != 'action':  # actions have no expected_state
-                node_dict[item.id] = item.hash()
+                try:
+                    node_dict[item.id] = item.hash()
+                except FaultUnavailable:
+                    io.stderr(_("{x} {node}  {bundle}  {item}  ({msg})").format(
+                        bundle=bold(item.bundle.name),
+                        item=item.id,
+                        msg=yellow(_("Fault unavailable")),
+                        node=bold(self.name),
+                        x=yellow("»"),
+                    ))
         return node_dict
 
     def covered_by_autoskip_selector(self, autoskip_selector):
@@ -676,7 +686,21 @@ class Node:
         return False
 
     def hash(self):
-        return hash_state_dict(self.expected_state)
+        expected_state = self.expected_state
+        items_missing_faults = [
+            item for item in self.items
+            if item.ITEM_TYPE_NAME != 'action' and item.id not in expected_state
+        ]
+        if items_missing_faults:
+            # the affected items have already been reported by expected_state
+            raise FaultUnavailable(_(
+                "Faults unavailable for {count} of {total} items on {node}"
+            ).format(
+                count=len(items_missing_faults),
+                node=self.name,
+                total=len([i for i in self.items if i.ITEM_TYPE_NAME != 'action']),
+            ))
+        return hash_state_dict(expected_state)
 
     def in_any_group(self, group_list):
         for group_name in group_list:

--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -1169,38 +1169,38 @@ def verify_items(
         return bool(items)
 
     def next_task():
-        while True:
-            try:
-                item = items.pop()
-            except IndexError:
-                return None
-            if item._faults_missing_for_attributes:
-                if item.error_on_missing_fault:
-                    item._raise_for_faults()
-                else:
-                    io.progress_advance()
-                    io.stdout(_("{x} {node}  {bundle}  {item}  ({msg})").format(
-                        bundle=bold(item.bundle.name),
-                        item=item.id,
-                        msg=yellow(_("Fault unavailable")),
-                        node=bold(node.name),
-                        x=yellow("»"),
-                    ))
-            else:
-                return {
-                    'task_id': node.name + ":" + item.bundle.name + ":" + item.id,
-                    'target': item.verify,
-                    'kwargs': {
-                        'autoskip_selector': autoskip_selector,
-                        'autoonly_selector': autoonly_selector,
-                    },
-                }
+        try:
+            item = items.pop()
+        except IndexError:
+            return None
+        return {
+            'task_id': node.name + ":" + item.bundle.name + ":" + item.id,
+            'target': item.verify,
+            'kwargs': {
+                'autoskip_selector': autoskip_selector,
+                'autoonly_selector': autoonly_selector,
+            },
+        }
 
     def handle_exception(task_id, exception, traceback):
         node_name, bundle_name, item_id = task_id.split(":", 2)
         io.progress_advance()
         if isinstance(exception, (ItemSkipped, NotImplementedError)):
             pass
+        elif (
+            isinstance(exception, FaultUnavailable) and
+            not node.get_item(item_id).error_on_missing_fault
+        ):
+            # Same as in Item.apply(): a missing Fault (typically a key
+            # missing from .secrets.cfg) means we can't know the expected
+            # state, not that the item is broken. Counts as "unknown".
+            io.stdout(_("{x} {node}  {bundle}  {item}  ({msg})").format(
+                bundle=bold(bundle_name),
+                item=item_id,
+                msg=yellow(_("Fault unavailable")),
+                node=bold(node_name),
+                x=yellow("»"),
+            ))
         else:
             # Unlike with `bw apply`, it is OK for `bw verify` to encounter
             # exceptions when getting an item's status. `bw verify` doesn't

--- a/tests/integration/bw_diff.py
+++ b/tests/integration/bw_diff.py
@@ -1,3 +1,5 @@
+from os.path import join
+
 from bundlewrap.utils.testing import make_repo, run
 
 
@@ -93,3 +95,210 @@ def test_whole_node(tmpdir):
     assert b"/tmp/bar" not in stdout
     assert stderr == b""
     assert rcode == 0
+
+
+def test_fault_unavailable(tmpdir):
+    make_repo(
+        tmpdir,
+        nodes={
+            "node1": {'bundles': ["bundle1", "bundle3"]},
+            "node2": {'bundles': ["bundle2", "bundle3"]},
+        },
+        bundles={
+            "bundle1": {
+                'items': {
+                    "files": {
+                        "/tmp/foo": {
+                            'content': "one",
+                        },
+                    },
+                },
+            },
+            "bundle2": {
+                'items': {
+                    "files": {
+                        "/tmp/foo": {
+                            'content': "two",
+                        },
+                    },
+                },
+            },
+            "bundle3": {
+                'items': {
+                    "files": {
+                        "/tmp/secret": {
+                            'content': "${repo.vault.password_for('test', key='404')}",
+                            'content_type': 'mako',
+                        },
+                    },
+                },
+            },
+        },
+    )
+    # whole node: the item with the missing Fault is skipped, the rest is diffed
+    stdout, stderr, rcode = run("bw diff node1 node2", path=str(tmpdir))
+    assert rcode == 0
+    assert b"file:/tmp/foo" in stdout
+    assert b"file:/tmp/secret" not in stdout
+    assert b"file:/tmp/secret  (Fault unavailable)" in stderr
+    assert b"Traceback" not in stderr
+
+    # single item: nothing to diff without the Fault
+    stdout, stderr, rcode = run("bw diff -i file:/tmp/secret -- node1 node2", path=str(tmpdir))
+    assert rcode == 1
+    assert b"file:/tmp/secret  (Fault unavailable)" in stderr
+    assert b"Traceback" not in stderr
+
+
+def test_fault_unavailable_attribute(tmpdir):
+    make_repo(
+        tmpdir,
+        nodes={
+            "node1": {'bundles': ["bundle1"]},
+            "node2": {'bundles': ["bundle1"]},
+        },
+        bundles={"bundle1": {}},
+    )
+    with open(join(str(tmpdir), "bundles", "bundle1", "items.py"), 'w') as f:
+        f.write("""
+files = {
+    "/tmp/secret": {
+        'content': repo.vault.password_for('test', key='404'),
+    },
+}
+""")
+    stdout, stderr, rcode = run("bw diff -i file:/tmp/secret -- node1 node2", path=str(tmpdir))
+    assert rcode == 1
+    assert b"file:/tmp/secret  (Fault unavailable)" in stderr
+    assert b"Traceback" not in stderr
+
+
+def test_delete_items(tmpdir):
+    make_repo(
+        tmpdir,
+        nodes={
+            "node1": {'bundles': ["bundle1"]},
+            "node2": {'bundles': ["bundle1"]},
+        },
+        bundles={
+            "bundle1": {
+                'items': {
+                    "files": {
+                        "/tmp/gone": {
+                            'delete': True,
+                        },
+                    },
+                },
+            },
+        },
+    )
+    stdout, stderr, rcode = run("bw diff -i file:/tmp/gone -- node1 node2", path=str(tmpdir))
+    assert rcode == 0
+    assert stderr == b""
+
+
+def test_metadata_fault_unavailable(tmpdir):
+    make_repo(tmpdir)
+    with open(join(str(tmpdir), "nodes.py"), 'w') as f:
+        f.write("""
+nodes = {
+    'node1': {
+        'metadata': {'secret': vault.password_for("testing", key="404"), 'foo': 1},
+    },
+    'node2': {
+        'metadata': {'secret': vault.password_for("testing", key="404"), 'foo': 2},
+    },
+}
+""")
+    stdout, stderr, rcode = run("bw diff -m node1 node2", path=str(tmpdir))
+    assert rcode == 0
+    assert b"Traceback" not in stderr
+    assert b"Fault unavailable" in stderr
+    # both sides are rendered unresolved, so the shared Fault is not a difference
+    assert not [
+        line for line in stdout.splitlines()
+        if line.startswith((b"-", b"+")) and b"secret" in line
+    ]
+    assert b'-    "foo": 1' in stdout
+    assert b'+    "foo": 2' in stdout
+
+
+def _git_repo_with_branch(tmpdir, branch_edit):
+    """
+    Turns tmpdir into a git repo on branch 'main' and creates a branch
+    'other' with the given edit applied (a callable taking tmpdir).
+    """
+    git = "git -c user.email=t@example.com -c user.name=t -c commit.gpgsign=false "
+    run(git + "init -q -b main", path=str(tmpdir))
+    run(git + "add -A && " + git + "commit -q -m base", path=str(tmpdir))
+    run(git + "checkout -q -b other", path=str(tmpdir))
+    branch_edit(tmpdir)
+    run(git + "add -A && " + git + "commit -q -m other", path=str(tmpdir))
+    run(git + "checkout -q main", path=str(tmpdir))
+
+
+def test_branch_metadata_fault_unavailable(tmpdir):
+    make_repo(
+        tmpdir,
+        nodes={
+            "node1": {'metadata': {'secret': "plain"}},
+            "node2": {'metadata': {'secret': "plain"}},
+        },
+    )
+
+    def edit(tmpdir):
+        with open(join(str(tmpdir), "nodes.py"), 'w') as f:
+            f.write("""
+nodes = {
+    'node1': {'metadata': {'secret': vault.password_for("testing", key="404")}},
+    'node2': {'metadata': {'secret': vault.password_for("testing", key="404")}},
+}
+""")
+    _git_repo_with_branch(tmpdir, edit)
+
+    for command in ("bw diff -m -b other node1", "bw diff -m -b other node1 node2"):
+        stdout, stderr, rcode = run(command, path=str(tmpdir))
+        assert rcode == 0, command
+        assert b"Traceback" not in stderr, command
+        assert b"Fault unavailable" in stderr, command
+        branch, _, _ = run("git rev-parse --abbrev-ref HEAD", path=str(tmpdir))
+        assert branch.strip() == b"main", command
+
+
+def test_branch_item_fault_unavailable(tmpdir):
+    make_repo(
+        tmpdir,
+        nodes={"node1": {'bundles': ["bundle1"]}},
+        bundles={
+            "bundle1": {
+                'items': {
+                    "files": {
+                        "/tmp/secret": {
+                            'content': "plain",
+                        },
+                    },
+                },
+            },
+        },
+    )
+
+    def edit(tmpdir):
+        with open(join(str(tmpdir), "bundles", "bundle1", "items.py"), 'w') as f:
+            f.write("""
+files = {
+    "/tmp/secret": {
+        'content': "${repo.vault.password_for('test', key='404')}",
+        'content_type': 'mako',
+    },
+}
+""")
+    _git_repo_with_branch(tmpdir, edit)
+
+    stdout, stderr, rcode = run("bw diff -i file:/tmp/secret -b other node1", path=str(tmpdir))
+    assert rcode == 1
+    assert b"Traceback" not in stderr
+    assert b"file:/tmp/secret  (Fault unavailable)" in stderr
+    # the available side must not be presented as an added/removed item
+    assert b"plain" not in stdout
+    branch, _, _ = run("git rev-parse --abbrev-ref HEAD", path=str(tmpdir))
+    assert branch.strip() == b"main"

--- a/tests/integration/bw_hash.py
+++ b/tests/integration/bw_hash.py
@@ -349,3 +349,38 @@ def test_groups_node_dict(tmpdir):
     stdout, stderr, rcode = run("bw hash -dg node1", path=str(tmpdir))
     assert rcode == 0
     assert stdout == b"group1\n"
+
+
+def test_fault_unavailable(tmpdir):
+    make_repo(
+        tmpdir,
+        nodes={
+            "node1": {
+                'bundles': ["bundle1"],
+            },
+        },
+        bundles={
+            "bundle1": {
+                'items': {
+                    'files': {
+                        "/test": {
+                            'content': "${repo.vault.password_for('test', key='404')}",
+                            'content_type': 'mako',
+                        },
+                    },
+                },
+            },
+        },
+    )
+
+    for command in (
+        "bw hash",
+        "bw hash node1",
+        "bw hash -d node1",
+        "bw hash node1 file:/test",
+        "bw hash -d node1 file:/test",
+    ):
+        stdout, stderr, rcode = run(command, path=str(tmpdir))
+        assert rcode == 1, command
+        assert b"Fault unavailable" in stderr, command
+        assert b"Traceback" not in stderr, command

--- a/tests/integration/bw_items.py
+++ b/tests/integration/bw_items.py
@@ -1,3 +1,5 @@
+from os.path import join
+
 from bundlewrap.utils.testing import make_repo, run
 
 
@@ -453,3 +455,51 @@ def test_bw_items_invocation_single_item_preview(tmpdir):
     _test_bw_items_invocation_succeeds(tmpdir, 'bw items --preview node1 file:/foo/bar/moo', """
 bar
 """.lstrip())
+
+
+def test_fault_unavailable_expected_state(tmpdir):
+    make_repo(
+        tmpdir,
+        nodes={
+            "node1": {
+                'bundles': ["bundle1"],
+            },
+        },
+        bundles={
+            "bundle1": {
+                'items': {
+                    'files': {
+                        "/test": {
+                            'content': "${repo.vault.password_for('test', key='404')}",
+                            'content_type': 'mako',
+                        },
+                    },
+                },
+            },
+        },
+    )
+
+    stdout, stderr, rcode = run("bw items node1 file:/test", path=str(tmpdir))
+    assert rcode == 1
+    assert b"Fault unavailable" in stderr
+    assert b"Traceback" not in stderr
+
+
+def test_fault_unavailable_attribute(tmpdir):
+    make_repo(
+        tmpdir,
+        nodes={"node1": {'bundles': ["bundle1"]}},
+        bundles={"bundle1": {}},
+    )
+    with open(join(str(tmpdir), "bundles", "bundle1", "items.py"), 'w') as f:
+        f.write("""
+files = {
+    "/test": {
+        'content': repo.vault.password_for('test', key='404'),
+    },
+}
+""")
+    stdout, stderr, rcode = run("bw items node1 file:/test", path=str(tmpdir))
+    assert rcode == 1
+    assert b"Fault unavailable" in stderr
+    assert b"Traceback" not in stderr

--- a/tests/integration/bw_test.py
+++ b/tests/integration/bw_test.py
@@ -1116,3 +1116,74 @@ def test_file_test_with_succeds(tmpdir):
     stdout, stderr, rcode = run("bw test localhost", path=str(tmpdir))
     assert rcode == 0
     assert b'failed local validation using: true' not in stderr
+
+
+def test_fault_missing_determinism(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "bundle1": {
+                'items': {
+                    "files": {
+                        "/foo": {
+                            'content_type': 'mako',
+                            'content': "${repo.vault.decrypt('bzzt', key='unavailable')}",
+                        },
+                    },
+                },
+            },
+        },
+    )
+    with open(join(str(tmpdir), "nodes.py"), 'w') as f:
+        f.write("""
+nodes = {
+    'node1': {
+        'bundles': ["bundle1"],
+        'metadata': {'foo': vault.password_for("test", key="unavailable")},
+    },
+}
+""")
+    for command in ("bw test -d 2", "bw test -m 2"):
+        stdout, stderr, rcode = run(command, path=str(tmpdir))
+        assert rcode == 1, command
+        assert b"Fault unavailable" in stderr, command
+        assert b"Traceback" not in stderr, command
+    for command in ("bw test -i -d 3", "bw test -i -m 3"):
+        stdout, stderr, rcode = run(command, path=str(tmpdir))
+        assert rcode == 0, command
+        # reported once per node, not once per iteration
+        assert stderr.count(b"cannot check determinism") == 1, command
+
+
+def test_fault_missing_determinism_still_checks_metadata(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "bundle1": {
+                'items': {
+                    "files": {
+                        "/foo": {
+                            'content_type': 'mako',
+                            'content': "${repo.vault.decrypt('bzzt', key='unavailable')}",
+                        },
+                    },
+                },
+            },
+        },
+    )
+    with open(join(str(tmpdir), "nodes.py"), 'w') as f:
+        f.write("""
+from random import random
+nodes = {
+    'node1': {
+        'bundles': ["bundle1"],
+        'metadata': {'rnd': repr(random())},
+    },
+}
+""")
+    # the config check is skipped because of the missing Fault,
+    # the metadata check must still run and catch the nondeterminism
+    stdout, stderr, rcode = run("bw test -i -d 2 -m 2", path=str(tmpdir))
+    assert rcode == 1
+    assert b"Metadata for node node1 changed" in stderr
+    assert b"Traceback" not in stderr

--- a/tests/integration/bw_verify.py
+++ b/tests/integration/bw_verify.py
@@ -30,3 +30,93 @@ def test_empty_verify(tmpdir):
 
     stdout, stderr, rcode = run("bw verify localhost", path=str(tmpdir))
     assert rcode == 0
+
+
+def test_fault_unavailable_in_template(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'items': {},
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "items.py"), 'w') as f:
+        f.write("""
+files = {
+    "/tmp/bw_test_verify_fault": {
+        'content': "${repo.vault.password_for('fault', key='missing')}",
+        'content_type': 'mako',
+    },
+}
+""")
+    stdout, stderr, rcode = run("bw verify localhost", path=str(tmpdir))
+    assert rcode == 0
+    assert b"file:/tmp/bw_test_verify_fault  (Fault unavailable)" in stdout
+    assert b"Traceback" not in stderr
+    assert b"unable to get status" not in stderr
+
+
+def test_fault_unavailable_error_on_missing_fault(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'items': {},
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "items.py"), 'w') as f:
+        f.write("""
+files = {
+    "/tmp/bw_test_verify_fault_error": {
+        'content': "${repo.vault.password_for('fault', key='missing')}",
+        'content_type': 'mako',
+        'error_on_missing_fault': True,
+    },
+}
+""")
+    stdout, stderr, rcode = run("bw verify localhost", path=str(tmpdir))
+    assert b"(Fault unavailable)" not in stdout
+    assert b"unable to get status" in stderr
+
+
+def test_fault_unavailable_attribute(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'items': {},
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "items.py"), 'w') as f:
+        f.write("""
+files = {
+    "/tmp/bw_test_verify_fault_attr": {
+        'content': repo.vault.password_for('fault', key='missing'),
+    },
+}
+""")
+    stdout, stderr, rcode = run("bw verify localhost", path=str(tmpdir))
+    assert rcode == 0
+    assert b"file:/tmp/bw_test_verify_fault_attr  (Fault unavailable)" in stdout
+    assert b"Traceback" not in stderr


### PR DESCRIPTION
`bw apply` already skips an item when a Fault becomes unavailable while computing its expected state (e.g. inside a template). `bw verify` only handled Faults detected at item creation; a Fault surfacing later ended up in the generic exception handler and printed a full traceback as "unable to get status".

Treat it like the early check: print a yellow "Fault unavailable" line and count the item as unknown.


Claude-Session: https://claude.ai/code/session_01KyF5kCuP8utyDgND7enAB8