### PR TITLE
bw verify: skip on fault unavailable

### DIFF
--- a/bundlewrap/node.py
+++ b/bundlewrap/node.py
@@ -13,6 +13,7 @@ from .concurrency import WorkerPool
 from .deps import find_item, ItemDependencyLoop
 from .exceptions import (
     BundleError,
+    FaultUnavailable,
     GracefulApplyException,
     ItemSkipped,
     NodeLockedException,
@@ -1145,38 +1146,44 @@ def verify_items(
         return bool(items)
 
     def next_task():
-        while True:
-            try:
-                item = items.pop()
-            except IndexError:
-                return None
-            if item._faults_missing_for_attributes:
-                if item.error_on_missing_fault:
-                    item._raise_for_faults()
-                else:
-                    io.progress_advance()
-                    io.stdout(_("{x} {node}  {bundle}  {item}  ({msg})").format(
-                        bundle=bold(item.bundle.name),
-                        item=item.id,
-                        msg=yellow(_("Fault unavailable")),
-                        node=bold(node.name),
-                        x=yellow("»"),
-                    ))
-            else:
-                return {
-                    'task_id': node.name + ":" + item.bundle.name + ":" + item.id,
-                    'target': item.verify,
-                    'kwargs': {
-                        'autoskip_selector': autoskip_selector,
-                        'autoonly_selector': autoonly_selector,
-                    },
-                }
+        try:
+            item = items.pop()
+        except IndexError:
+            return None
+        return {
+            'task_id': node.name + ":" + item.bundle.name + ":" + item.id,
+            'target': item.verify,
+            'kwargs': {
+                'autoskip_selector': autoskip_selector,
+                'autoonly_selector': autoonly_selector,
+            },
+        }
 
     def handle_exception(task_id, exception, traceback):
         node_name, bundle_name, item_id = task_id.split(":", 2)
         io.progress_advance()
         if isinstance(exception, (ItemSkipped, NotImplementedError)):
             pass
+        elif isinstance(exception, FaultUnavailable):
+            item = node.get_item(item_id)
+            if item.error_on_missing_fault:
+                io.stderr(_("{x} {node}  {bundle}  {item}  ({msg})").format(
+                    bundle=bold(bundle_name),
+                    item=item_id,
+                    msg=red(_("Fault unavailable")),
+                    node=bold(node_name),
+                    x=red("!"),
+                ))
+                return False
+            else:
+                io.stdout(_("{x} {node}  {bundle}  {item}  ({msg})").format(
+                    bundle=bold(bundle_name),
+                    item=item_id,
+                    msg=yellow(_("Fault unavailable")),
+                    node=bold(node_name),
+                    x=yellow("»"),
+                ))
+                return None
         else:
             # Unlike with `bw apply`, it is OK for `bw verify` to encounter
             # exceptions when getting an item's status. `bw verify` doesn't

--- a/tests/integration/bw_verify.py
+++ b/tests/integration/bw_verify.py
@@ -30,3 +30,32 @@ def test_empty_verify(tmpdir):
 
     stdout, stderr, rcode = run("bw verify localhost", path=str(tmpdir))
     assert rcode == 0
+
+
+def test_fault_content_unavailable_skipped(tmpdir):
+    make_repo(
+        tmpdir,
+        bundles={
+            "test": {
+                'items': {},
+            },
+        },
+        nodes={
+            "localhost": {
+                'bundles': ["test"],
+                'os': host_os(),
+            },
+        },
+    )
+    with open(join(str(tmpdir), "bundles", "test", "items.py"), 'w') as f:
+        f.write("""
+files = {
+    "/tmp/bw_test_faultunavailable": {
+        'content': repo.vault.password_for("fault", key="missing"),
+    },
+}
+""")
+    stdout, stderr, rcode = run("bw verify localhost", path=str(tmpdir))
+    assert rcode == 0
+    assert b"file:/tmp/bw_test_faultunavailable  (Fault unavailable)" in stdout
+    assert b"unable to get status" not in stderr


### PR DESCRIPTION
instead of throwing a stacktrace